### PR TITLE
python based Backend added to scan raid images and update database

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -28,7 +28,8 @@ Download all fort URL images in `Forts` table. Set `MAP_START` and `MAP_END` in 
 1. Run `python3.6 downloadfortimg.py` once to download all gym(fort) URL image
 2. Run `python3.6 raidscan.py` to scan raid images
 3. Run `python3.6 findfort.py` to find gym if there is unknow gym
-4. Run `python3.6 manualsubmit.py` once you set `Fort_xxx.png` and `Pokemon_yyy.png` in `not_find_img` directory.
+4. Run `bash crop_backend.bash` to crop captured screenshot and send to `process_img` folder for `raidscan.py`
+5. Run `python3.6 manualsubmit.py` once you set `Fort_xxx.png` and `Pokemon_yyy.png` in `not_find_img` directory.
 
 ## Setting up
 1. Install Python 3.6 (<https://www.python.org/downloads/release/python-365/>)

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -8,6 +8,7 @@ Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted in
 	* start time
 2. Update raids and fort_sightings in monocle (Hydro) database
 3. Download gym(fort) url images and find matching gym automatically. Up to 99% of gyms are detected successfully.
+4. MySQL and Postgresql supported.
 
 ## Setting up
 1. Install Python 3.6
@@ -21,12 +22,13 @@ Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted in
 	* If you don't have MySQL on your machine, comment out mysqlclient
 	* If you don't have Postgresql on your machine, commment out psycopg2 and psycopg2-binary
 5. Configure config.py to set your monocle database
-6. Run `python3.6 raidscan.py` from the command line
+6. Run `python3.6 raidscan.py` from the command line. When first run, raid_images and pokemon_images tables are added automatically.
 7. Open another terminal and activate venv as in step 3
 8. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort image in database set `MAP_START` and `MAP_END`.
 9. Wait finish download fort images, then run `python3.6 findfort.py`
 10. Open crop_backend.bash and edit `RDRM_HOME_PATH` to your RealDeviceRaidMap directory.
 11. Run `bach crop_backend.bash`. **Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash**. No worry. Backend can identify gym images over 95% of gyms automatically (Without user input).
 12. Wait until all gyms are identified.
+13. `PokemonImage_xxx.png` files are stored in /unknown_img/ directory. Rename the file to `Pokemon_PokemonId.png`(e.g. `Pokemon_380.png` for Latias) and run `python3.6 manualsubmit.py`. This will train pokemon raid boss. Usually only one time training should be enough.
 
 

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,6 +1,14 @@
 # RealDeviceRaidMap Backend
 Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted information to monocle hydro database. Most of gym iamges are identified automatically.
 
+## Features
+1. Read raid sightings images and identify
+	* gym 
+	* raid boss
+	* start time
+2. Update raids and fort_sightings in monocle (Hydro) database
+3. Download gym(fort) url images and find matching gym automatically. Up to 99% of gyms are detected successfully.
+
 ## Setting up
 1. Install Python 3.6
 2. Create venv

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,0 +1,1 @@
+**RealDeviceRaidMap Backend**

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -16,4 +16,9 @@ Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted in
 6. Run `python3.6 raidscan.py` from the command line
 7. Open another terminal and activate venv as in step 3
 8. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort image in database set `MAP_START` and `MAP_END`.
-9. 
+9. Wait finish download fort images, then run `python3.6 findfort.py`
+10. Open crop_backend.bash and edit `RDRM_HOME_PATH` to your RealDeviceRaidMap directory.
+11. Run `bach crop_backend.bash`. ** Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash **. No worry. Backend can identify gym images over 95% of gyms automatically (Without user input).
+12. Wait until all gyms are identified.
+
+

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -18,7 +18,7 @@ Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted in
 8. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort image in database set `MAP_START` and `MAP_END`.
 9. Wait finish download fort images, then run `python3.6 findfort.py`
 10. Open crop_backend.bash and edit `RDRM_HOME_PATH` to your RealDeviceRaidMap directory.
-11. Run `bach crop_backend.bash`. ** Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash **. No worry. Backend can identify gym images over 95% of gyms automatically (Without user input).
+11. Run `bach crop_backend.bash`. **Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash**. No worry. Backend can identify gym images over 95% of gyms automatically (Without user input).
 12. Wait until all gyms are identified.
 
 

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,2 +1,2 @@
 # RealDeviceRaidMap Backend
-Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted information to moncle hydro database. Most of gym iamges are identified automatically.
+Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted information to monocle hydro database. Most of gym iamges are identified automatically.

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -11,26 +11,44 @@ Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted in
 4. Download gym(fort) url images and find matching gym automatically. Up to 99% of gyms are detected successfully.
 5. MySQL and Postgresql supported.
 
+## How it works
+### raidscan.py
+Read all raid sightings png images cropped by `crop_backend.bash` in `process_img` directory and extract gym/raid boss/hatch time information and update `raids` and `fort_sightings` table for monocle Hydro database. If raidscan.py can't identify the gym then the gym image is stored in `unknown_img` as `FortImage_xxx.png`. Once gym is identified, check level and time. If time is Ongoing, then try to identify raid boss by checking `pokemon_images` table. If the raid boss is unknown, then store the raid boss image into `unknow_img` as PokemonImage_xxx.png.
+
+### findfort.py
+Read all gym images in `unknown_img` and identify the gym image by comparing fort URL images in `url_img`. If findfort.py finds matching gym(fort) in `url_img`, then update `gym_images` table to set identified `fort_id`. findfort.py checks images every 30 seconds. Fort URL images need to be downloaded by `downloadfortimg.py` before running `findfort.py`.
+
+### downloadfortimg.py
+Download all fort URL images in `Forts` table. Set `MAP_START` and `MAP_END` in `config.py` to limit fort URL images to download if you want.
+
+### manualsubmit.py
+`manualsubmit.py` update `fort_id` in `gym_images` and `pokemon_id` in `pokemon_images` by reading `Fort_xxx.png` and `Pokemon_yyy.png` in `not_find_img`. User need to set xxx for `fort_id` and yyy for `pokemon_id` manually. This part need to be integrated with `Frontend` in the future.
+
+### Running order
+1. Run `python3.6 downloadfortimg.py` once to download all gym(fort) URL image
+2. Run `python3.6 raidscan.py` to scan raid images
+3. Run `python3.6 findfort.py` to find gym if there is unknow gym
+4. Run `python3.6 manualsubmit.py` once you set `Fort_xxx.png` and `Pokemon_yyy.png` in `not_find_img` directory.
 
 ## Setting up
-1. Install Python 3.6
-2. Create venv
-	`python3.6 -m venv path/to/create/venv`
+1. Install Python 3.6 (<https://www.python.org/downloads/release/python-365/>)
+2. Install imagemagick 7+ `brew install imagemagick`
+3. Install tesseract `brew install tesseract`
+4. Create venv
+    `python3.6 -m venv path/to/create/venv`
 	example: `python3.6 -m venv ~/venv_rdrm`
-3. Activate venv
-	`source ~/venv_rdrm/bin/activate`
-4. Install requirements
-	`pip3.6 install -r requirements.txt -U`
-	* If you don't have MySQL on your machine, comment out mysqlclient
-	* If you don't have Postgresql on your machine, commment out psycopg2 and psycopg2-binary
-5. Configure config.py to set your monocle database
-6. Run `python3.6 raidscan.py` from the command line. When first run, raid_images and pokemon_images tables are added automatically.
-7. Open another terminal and activate venv as in step 3
-8. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort images in database, set `MAP_START` and `MAP_END` in `config.py`.
-9. Wait finish download fort images, then run `python3.6 findfort.py`
-10. Open crop_backend.bash and edit `RDRM_HOME_PATH` to your RealDeviceRaidMap directory.
-11. Run `bach crop_backend.bash`. **Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash**. Don't worry, Backend can identify gym images up to 99% of gyms automatically (without user input).
-12. Wait until all gyms are identified. Check `success_img` and `need_check_img` directory to make sure all gym images are correctly identified.
-13. `PokemonImage_xxx.png` files are stored in `unknown_img` directory. Rename the file to `Pokemon_PokemonId.png`(e.g. `Pokemon_380.png` for Latias) and run `python3.6 manualsubmit.py`. This will train pokemon raid boss. Usually only one time training should be enough.
-
-
+5. Activate venv
+    `source ~/venv_rdrm/bin/activate`
+6. Install requirements
+    `pip3.6 install -r requirements.txt -U`
+    * If you don't have MySQL on your machine, comment out mysqlclient
+    * If you don't have Postgresql on your machine, commment out psycopg2 and psycopg2-binary
+7. Configure config.py to set your monocle database
+8. Run `python3.6 raidscan.py` from the command line. When first run, raid_images and pokemon_images tables are added automatically.
+9. Open another terminal and activate venv as in step 3
+10. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort images in database, set `MAP_START` and `MAP_END` in `config.py`.
+11. Wait finish download fort images, then run `python3.6 findfort.py`
+12. Open crop_backend.bash and edit `RDRM_HOME_PATH` to your RealDeviceRaidMap directory.
+13. Run `bach crop_backend.bash`. **Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash**. Don't worry, Backend can identify gym images up to 99% of gyms automatically (without user input).
+14. Wait until all gyms are identified. Check `success_img` and `need_check_img` directory to make sure all gym images are correctly identified.
+15. `PokemonImage_xxx.png` files are stored in `unknown_img` directory. Rename the file to `Pokemon_PokemonId.png`(e.g. `Pokemon_380.png` for Latias) and run `python3.6 manualsubmit.py`. This will train pokemon raid boss. Usually only one time training should be enough.

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -24,11 +24,11 @@ Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted in
 5. Configure config.py to set your monocle database
 6. Run `python3.6 raidscan.py` from the command line. When first run, raid_images and pokemon_images tables are added automatically.
 7. Open another terminal and activate venv as in step 3
-8. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort image in database set `MAP_START` and `MAP_END`.
+8. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort images in database, set `MAP_START` and `MAP_END` in `config.py`.
 9. Wait finish download fort images, then run `python3.6 findfort.py`
 10. Open crop_backend.bash and edit `RDRM_HOME_PATH` to your RealDeviceRaidMap directory.
-11. Run `bach crop_backend.bash`. **Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash**. No worry. Backend can identify gym images over 95% of gyms automatically (Without user input).
-12. Wait until all gyms are identified.
-13. `PokemonImage_xxx.png` files are stored in /unknown_img/ directory. Rename the file to `Pokemon_PokemonId.png`(e.g. `Pokemon_380.png` for Latias) and run `python3.6 manualsubmit.py`. This will train pokemon raid boss. Usually only one time training should be enough.
+11. Run `bach crop_backend.bash`. **Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash**. Don't worry, Backend can identify gym images up to 99% of gyms automatically (without user input).
+12. Wait until all gyms are identified. Check `success_img` and `need_check_img` directory to make sure all gym images are correctly identified.
+13. `PokemonImage_xxx.png` files are stored in `unknown_img` directory. Rename the file to `Pokemon_PokemonId.png`(e.g. `Pokemon_380.png` for Latias) and run `python3.6 manualsubmit.py`. This will train pokemon raid boss. Usually only one time training should be enough.
 
 

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,2 +1,0 @@
-# RealDeviceRaidMap Backend
-Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted information to monocle hydro database. Most of gym iamges are identified automatically.

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,1 +1,2 @@
-**RealDeviceRaidMap Backend**
+# RealDeviceRaidMap Backend
+Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted information to moncle hydro database. Most of gym iamges are identified automatically.

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,2 +1,19 @@
 # RealDeviceRaidMap Backend
 Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted information to monocle hydro database. Most of gym iamges are identified automatically.
+
+## Setting up
+1. Install Python 3.6
+2. Create venv
+	`python3.6 -m venv path/to/create/venv`
+	example: `python3.6 -m venv ~/venv_rdrm`
+3. Activate venv
+	`source ~/venv_rdrm/bin/activate`
+4. Install requirements
+	`pip3.6 install -r requirements.txt -U`
+	* If you don't have MySQL on your machine, comment out mysqlclient
+	* If you don't have Postgresql on your machine, commment out psycopg2 and psycopg2-binary
+5. Configure config.py to set your monocle database
+6. Run `python3.6 raidscan.py` from the command line
+7. Open another terminal and activate venv as in step 3
+8. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort image in database set `MAP_START` and `MAP_END`.
+9. 

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,0 +1,2 @@
+# RealDeviceRaidMap Backend
+Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted information to monocle hydro database. Most of gym iamges are identified automatically.

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -6,9 +6,11 @@ Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted in
 	* gym 
 	* raid boss
 	* start time
-2. Update raids and fort_sightings in monocle (Hydro) database
-3. Download gym(fort) url images and find matching gym automatically. Up to 99% of gyms are detected successfully.
-4. MySQL and Postgresql supported.
+2. Parameters to identify gym and raid boss are stored in gym_images and pokemon_images table automatically.
+3. Update raids and fort_sightings tables in monocle (Hydro) database
+4. Download gym(fort) url images and find matching gym automatically. Up to 99% of gyms are detected successfully.
+5. MySQL and Postgresql supported.
+
 
 ## Setting up
 1. Install Python 3.6

--- a/Backend/config.py
+++ b/Backend/config.py
@@ -1,6 +1,6 @@
 
-DB_ENGINE = 'mysql://root:Mysql0924@192.168.1.36:3306/monocle_raid?charset=utf8'
-#DB_ENGINE = 'postgres://postgres:postgres@192.168.1.36:5432/monocle_raid'
+DB_ENGINE = 'mysql://user:pass@192.168.1.36:3306/monocle_raid?charset=utf8'
+#DB_ENGINE = 'postgres://user:pass@192.168.1.36:5432/monocle_raid'
 
 # the corner points of a rectangle for download gym url image
 # If either of them is (0, 0) then download all gym url image in database

--- a/Backend/config.py
+++ b/Backend/config.py
@@ -1,3 +1,11 @@
 
-#DB_ENGINE = 'mysql://root:mysql@192.168.1.36:3306/monocle_raid?charset=utf8'
-DB_ENGINE = 'postgres://postgres:postgres@192.168.1.36:5432/monocle_raid'
+DB_ENGINE = 'mysql://root:Mysql0924@192.168.1.36:3306/monocle_raid?charset=utf8'
+#DB_ENGINE = 'postgres://postgres:postgres@192.168.1.36:5432/monocle_raid'
+
+# the corner points of a rectangle for download gym url image
+# If either of them is (0, 0) then download all gym url image in database
+MAP_START = (0,0)
+MAP_END = (0,0)
+#MAP_START = (41.89588847196377,-87.65613555908205)
+#MAP_END = (41.84271080015277,-87.61476516723633)
+

--- a/Backend/config.py
+++ b/Backend/config.py
@@ -1,0 +1,3 @@
+
+#DB_ENGINE = 'mysql://root:mysql@192.168.1.36:3306/monocle_raid?charset=utf8'
+DB_ENGINE = 'postgres://postgres:postgres@192.168.1.36:5432/monocle_raid'

--- a/Backend/crop_backend.bash
+++ b/Backend/crop_backend.bash
@@ -90,20 +90,20 @@ do
 
 		if [ "$HASH" == "235e2af860fe01bd3da8809d897b31bb" ]
 		then
-			cp ImageInput.png ImageFull1.png
-			mogrify -crop "$FULL_SIZE"+"$FULL_X1"+"$FULL_Y1" -strip +repage ImageFull1.png
-			cp ImageInput.png ImageFull2.png
-			mogrify -crop "$FULL_SIZE"+"$FULL_X2"+"$FULL_Y1" -strip +repage ImageFull2.png
-			cp ImageInput.png ImageFull3.png
-			mogrify -crop "$FULL_SIZE"+"$FULL_X3"+"$FULL_Y1" -strip +repage ImageFull3.png
-			cp ImageInput.png ImageFull4.png
-			mogrify -crop "$FULL_SIZE"+"$FULL_X1"+"$FULL_Y2" -strip +repage ImageFull4.png
-			cp ImageInput.png ImageFull5.png
-			mogrify -crop "$FULL_SIZE"+"$FULL_X2"+"$FULL_Y2" -strip +repage ImageFull5.png
-			cp ImageInput.png ImageFull6.png
-			mogrify -crop "$FULL_SIZE"+"$FULL_X3"+"$FULL_Y2" -strip +repage ImageFull6.png
+            cp ImageInput.png ImageFull1.png
+            mogrify -crop "$FULL_SIZE"+"$FULL_X1"+"$FULL_Y1" -strip +repage ImageFull1.png
+            cp ImageInput.png ImageFull2.png
+            mogrify -crop "$FULL_SIZE"+"$FULL_X2"+"$FULL_Y1" -strip +repage ImageFull2.png
+            cp ImageInput.png ImageFull3.png
+            mogrify -crop "$FULL_SIZE"+"$FULL_X3"+"$FULL_Y1" -strip +repage ImageFull3.png
+            cp ImageInput.png ImageFull4.png
+            mogrify -crop "$FULL_SIZE"+"$FULL_X1"+"$FULL_Y2" -strip +repage ImageFull4.png
+            cp ImageInput.png ImageFull5.png
+            mogrify -crop "$FULL_SIZE"+"$FULL_X2"+"$FULL_Y2" -strip +repage ImageFull5.png
+            cp ImageInput.png ImageFull6.png
+            mogrify -crop "$FULL_SIZE"+"$FULL_X3"+"$FULL_Y2" -strip +repage ImageFull6.png
 
-			mv ImageFull1.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"01.png
+            mv ImageFull1.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"01.png
             mv ImageFull2.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"02.png
             mv ImageFull3.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"03.png
             mv ImageFull4.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"04.png

--- a/Backend/crop_backend.bash
+++ b/Backend/crop_backend.bash
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+while true
+
+RDRM_HOME_PATH="/Path/to/RealDeviceRaidMap/"
+
+do
+	mkdir Output-Temp &>/dev/null
+    mkdir Input &>/dev/null
+    mv ~/Library/Developer/Xcode/DerivedData/RDRaidMapCtrl-*/Logs/Test/Attachments/*.png Input &>/dev/null
+    rm -f ~/Library/Developer/Xcode/DerivedData/RDRaidMapCtrl-*/Logs/Test/Attachments/*.jpg &>/dev/null
+	FILE=$(ls Input | head -1)
+	if [ "$FILE" != "" ]
+	then
+		mv "Input/$FILE" ImageInput.png
+		
+		WIDTH=$(identify -format "%w" "ImageInput.png")> /dev/null
+
+		if [ "$WIDTH" == "750" ] #iPhone
+		then			
+			MON_SIZE="84x84"
+			MON_X1=119
+			MON_X2=338
+			MON_X3=556
+			MON_Y1=555
+			MON_Y2=878
+			
+			TIME_SIZE="157x30"
+			TIME_X1=83
+			TIME_X2=302
+			TIME_X3=520
+			TIME_Y1=712
+			TIME_Y2=1035
+			
+			FULL_SIZE="157x260"
+			FULL_X1=83
+			FULL_X2=302
+			FULL_X3=520
+			FULL_Y1=519
+			FULL_Y2=842
+			
+			LEVEL_SIZE="157x30"
+			LEVEL_X1=83
+			LEVEL_X2=302
+			LEVEL_X3=520
+			LEVEL_Y1=749
+			LEVEL_Y2=1072
+			
+			COMPARE_X=85
+			COMPARE_Y=595
+		elif [ "$WIDTH" == "1536" ]
+		then			
+			MON_SIZE="172x172"
+			MON_X1=244
+			MON_X2=692
+			MON_X3=1140
+			MON_Y1=453
+			MON_Y2=1115
+			
+			TIME_SIZE="320x45"
+			TIME_X1=170
+			TIME_X2=618
+			TIME_X3=1066
+			TIME_Y1=785
+			TIME_Y2=1447
+			
+			FULL_SIZE="320x525"
+			FULL_X1=170
+			FULL_X2=618
+			FULL_X3=1066
+			FULL_Y1=379
+			FULL_Y2=1041
+			
+			LEVEL_SIZE="320x60"
+			LEVEL_X1=170
+			LEVEL_X2=618
+			LEVEL_X3=1066
+			LEVEL_Y1=855
+			LEVEL_Y2=1517
+			
+			COMPARE_X=175
+			COMPARE_Y=535
+		fi
+
+		cp ImageInput.png ImageCompare.png
+		mogrify -crop 1x1+"$COMPARE_X"+"$COMPARE_Y" -strip +repage ImageCompare.png
+		HASH=$(md5 -q ImageCompare.png)
+
+		echo "$HASH"
+
+		if [ "$HASH" == "235e2af860fe01bd3da8809d897b31bb" ]
+		then
+			cp ImageInput.png ImageFull1.png
+			mogrify -crop "$FULL_SIZE"+"$FULL_X1"+"$FULL_Y1" -strip +repage ImageFull1.png
+			cp ImageInput.png ImageFull2.png
+			mogrify -crop "$FULL_SIZE"+"$FULL_X2"+"$FULL_Y1" -strip +repage ImageFull2.png
+			cp ImageInput.png ImageFull3.png
+			mogrify -crop "$FULL_SIZE"+"$FULL_X3"+"$FULL_Y1" -strip +repage ImageFull3.png
+			cp ImageInput.png ImageFull4.png
+			mogrify -crop "$FULL_SIZE"+"$FULL_X1"+"$FULL_Y2" -strip +repage ImageFull4.png
+			cp ImageInput.png ImageFull5.png
+			mogrify -crop "$FULL_SIZE"+"$FULL_X2"+"$FULL_Y2" -strip +repage ImageFull5.png
+			cp ImageInput.png ImageFull6.png
+			mogrify -crop "$FULL_SIZE"+"$FULL_X3"+"$FULL_Y2" -strip +repage ImageFull6.png
+
+			mv ImageFull1.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"01.png
+            mv ImageFull2.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"02.png
+            mv ImageFull3.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"03.png
+            mv ImageFull4.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"04.png
+            mv ImageFull5.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"05.png
+            mv ImageFull6.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"06.png
+
+		fi
+	fi
+	rm -f *.png
+	rm -f *.tif
+	sleep 0.1
+done

--- a/Backend/crop_backend.bash
+++ b/Backend/crop_backend.bash
@@ -5,91 +5,91 @@ while true
 RDRM_HOME_PATH="/Path/to/RealDeviceRaidMap/"
 
 do
-	mkdir Output-Temp &>/dev/null
+    mkdir Output-Temp &>/dev/null
     mkdir Input &>/dev/null
     mv ~/Library/Developer/Xcode/DerivedData/RDRaidMapCtrl-*/Logs/Test/Attachments/*.png Input &>/dev/null
     rm -f ~/Library/Developer/Xcode/DerivedData/RDRaidMapCtrl-*/Logs/Test/Attachments/*.jpg &>/dev/null
-	FILE=$(ls Input | head -1)
-	if [ "$FILE" != "" ]
-	then
-		mv "Input/$FILE" ImageInput.png
-		
-		WIDTH=$(identify -format "%w" "ImageInput.png")> /dev/null
+    FILE=$(ls Input | head -1)
+    if [ "$FILE" != "" ]
+    then
+        mv "Input/$FILE" ImageInput.png
+        
+        WIDTH=$(identify -format "%w" "ImageInput.png")> /dev/null
 
-		if [ "$WIDTH" == "750" ] #iPhone
-		then			
-			MON_SIZE="84x84"
-			MON_X1=119
-			MON_X2=338
-			MON_X3=556
-			MON_Y1=555
-			MON_Y2=878
-			
-			TIME_SIZE="157x30"
-			TIME_X1=83
-			TIME_X2=302
-			TIME_X3=520
-			TIME_Y1=712
-			TIME_Y2=1035
-			
-			FULL_SIZE="157x260"
-			FULL_X1=83
-			FULL_X2=302
-			FULL_X3=520
-			FULL_Y1=519
-			FULL_Y2=842
-			
-			LEVEL_SIZE="157x30"
-			LEVEL_X1=83
-			LEVEL_X2=302
-			LEVEL_X3=520
-			LEVEL_Y1=749
-			LEVEL_Y2=1072
-			
-			COMPARE_X=85
-			COMPARE_Y=595
-		elif [ "$WIDTH" == "1536" ]
-		then			
-			MON_SIZE="172x172"
-			MON_X1=244
-			MON_X2=692
-			MON_X3=1140
-			MON_Y1=453
-			MON_Y2=1115
-			
-			TIME_SIZE="320x45"
-			TIME_X1=170
-			TIME_X2=618
-			TIME_X3=1066
-			TIME_Y1=785
-			TIME_Y2=1447
-			
-			FULL_SIZE="320x525"
-			FULL_X1=170
-			FULL_X2=618
-			FULL_X3=1066
-			FULL_Y1=379
-			FULL_Y2=1041
-			
-			LEVEL_SIZE="320x60"
-			LEVEL_X1=170
-			LEVEL_X2=618
-			LEVEL_X3=1066
-			LEVEL_Y1=855
-			LEVEL_Y2=1517
-			
-			COMPARE_X=175
-			COMPARE_Y=535
-		fi
+        if [ "$WIDTH" == "750" ] #iPhone
+        then            
+            MON_SIZE="84x84"
+            MON_X1=119
+            MON_X2=338
+            MON_X3=556
+            MON_Y1=555
+            MON_Y2=878
+            
+            TIME_SIZE="157x30"
+            TIME_X1=83
+            TIME_X2=302
+            TIME_X3=520
+            TIME_Y1=712
+            TIME_Y2=1035
+            
+            FULL_SIZE="157x260"
+            FULL_X1=83
+            FULL_X2=302
+            FULL_X3=520
+            FULL_Y1=519
+            FULL_Y2=842
+            
+            LEVEL_SIZE="157x30"
+            LEVEL_X1=83
+            LEVEL_X2=302
+            LEVEL_X3=520
+            LEVEL_Y1=749
+            LEVEL_Y2=1072
+            
+            COMPARE_X=85
+            COMPARE_Y=595
+        elif [ "$WIDTH" == "1536" ]
+        then            
+            MON_SIZE="172x172"
+            MON_X1=244
+            MON_X2=692
+            MON_X3=1140
+            MON_Y1=453
+            MON_Y2=1115
+            
+            TIME_SIZE="320x45"
+            TIME_X1=170
+            TIME_X2=618
+            TIME_X3=1066
+            TIME_Y1=785
+            TIME_Y2=1447
+            
+            FULL_SIZE="320x525"
+            FULL_X1=170
+            FULL_X2=618
+            FULL_X3=1066
+            FULL_Y1=379
+            FULL_Y2=1041
+            
+            LEVEL_SIZE="320x60"
+            LEVEL_X1=170
+            LEVEL_X2=618
+            LEVEL_X3=1066
+            LEVEL_Y1=855
+            LEVEL_Y2=1517
+            
+            COMPARE_X=175
+            COMPARE_Y=535
+        fi
 
-		cp ImageInput.png ImageCompare.png
-		mogrify -crop 1x1+"$COMPARE_X"+"$COMPARE_Y" -strip +repage ImageCompare.png
-		HASH=$(md5 -q ImageCompare.png)
+        cp ImageInput.png ImageCompare.png
+        mogrify -crop 1x1+"$COMPARE_X"+"$COMPARE_Y" -strip +repage ImageCompare.png
+        HASH=$(md5 -q ImageCompare.png)
 
-		echo "$HASH"
+        echo "$HASH"
 
-		if [ "$HASH" == "235e2af860fe01bd3da8809d897b31bb" ]
-		then
+        if [ "$HASH" == "235e2af860fe01bd3da8809d897b31bb" ]
+        then
             cp ImageInput.png ImageFull1.png
             mogrify -crop "$FULL_SIZE"+"$FULL_X1"+"$FULL_Y1" -strip +repage ImageFull1.png
             cp ImageInput.png ImageFull2.png
@@ -110,9 +110,9 @@ do
             mv ImageFull5.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"05.png
             mv ImageFull6.png "$RDRM_HOME_PATH"Backend/process_img/"$FILE"06.png
 
-		fi
-	fi
-	rm -f *.png
-	rm -f *.tif
-	sleep 0.1
+        fi
+    fi
+    rm -f *.png
+    rm -f *.tif
+    sleep 0.1
 done

--- a/Backend/database.py
+++ b/Backend/database.py
@@ -1,0 +1,310 @@
+from pathlib import Path
+import os
+import time
+import math
+import datetime
+import time
+from sqlalchemy import create_engine, Column, Boolean, Integer, String, Float, SmallInteger, \
+        BigInteger, ForeignKey, Index, UniqueConstraint, \
+        create_engine, cast, func, desc, asc, desc, and_, exists
+from sqlalchemy.orm import sessionmaker, relationship, eagerload, foreign, remote
+from sqlalchemy.types import TypeDecorator, Numeric, Text, TIMESTAMP
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm.exc import NoResultFound
+
+from config import DB_ENGINE
+
+if DB_ENGINE.startswith('mysql'):
+    from sqlalchemy.dialects.mysql import TINYINT, MEDIUMINT, BIGINT, DOUBLE, LONGTEXT
+
+    TINY_TYPE = TINYINT(unsigned=True)          # 0 to 255
+    MEDIUM_TYPE = MEDIUMINT(unsigned=True)      # 0 to 4294967295
+    UNSIGNED_HUGE_TYPE = BIGINT(unsigned=True)  # 0 to 18446744073709551615
+    HUGE_TYPE = BigInteger
+    PRIMARY_HUGE_TYPE = HUGE_TYPE 
+    FLOAT_TYPE = DOUBLE(precision=18, scale=14, asdecimal=False)
+    LONG_TEXT = LONGTEXT
+elif DB_ENGINE.startswith('postgres'):
+    from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TEXT
+
+    class NumInt(TypeDecorator):
+        '''Modify Numeric type for integers'''
+        impl = Numeric
+
+        def process_bind_param(self, value, dialect):
+            if value is None:
+                return None
+            return int(value)
+
+        def process_result_value(self, value, dialect):
+            if value is None:
+                return None
+            return int(value)
+
+        @property
+        def python_type(self):
+            return int
+
+    TINY_TYPE = SmallInteger                    # -32768 to 32767
+    MEDIUM_TYPE = Integer                       # -2147483648 to 2147483647
+    UNSIGNED_HUGE_TYPE = NumInt(precision=20, scale=0)   # up to 20 digits
+    HUGE_TYPE = BigInteger
+    PRIMARY_HUGE_TYPE = HUGE_TYPE 
+    FLOAT_TYPE = DOUBLE_PRECISION(asdecimal=False)
+    LONG_TEXT = TEXT
+else:
+    class TextInt(TypeDecorator):
+        '''Modify Text type for integers'''
+        impl = Text
+
+        def process_bind_param(self, value, dialect):
+            return str(value)
+
+        def process_result_value(self, value, dialect):
+            return int(value)
+
+    TINY_TYPE = SmallInteger
+    MEDIUM_TYPE = Integer
+    UNSIGNED_HUGE_TYPE = TextInt
+    HUGE_TYPE = Integer
+    PRIMARY_HUGE_TYPE = HUGE_TYPE 
+    FLOAT_TYPE = Float(asdecimal=False)
+
+Base = declarative_base()
+engine = create_engine(DB_ENGINE)
+
+class Fort(Base):
+    __tablename__ = 'forts'
+
+    id = Column(Integer, primary_key=True)
+    external_id = Column(String(35), unique=True)
+    lat = Column(FLOAT_TYPE)
+    lon = Column(FLOAT_TYPE)
+    name = Column(String(128))
+    url = Column(String(200))
+    sponsor = Column(SmallInteger)
+    weather_cell_id = Column(UNSIGNED_HUGE_TYPE)
+    park = Column(String(128))
+    parkid = Column(HUGE_TYPE)
+
+    sightings = relationship(
+        'FortSighting',
+        backref='fort',
+        order_by='FortSighting.last_modified'
+    )
+
+    raids = relationship(
+        'Raid',
+        backref='fort',
+        order_by='Raid.time_end'
+    )
+
+class FortSighting(Base):
+    __tablename__ = 'fort_sightings'
+
+    id = Column(PRIMARY_HUGE_TYPE, primary_key=True)
+    fort_id = Column(Integer, ForeignKey('forts.id'))
+    last_modified = Column(Integer, index=True)
+    team = Column(TINY_TYPE)
+    guard_pokemon_id = Column(SmallInteger)
+    slots_available = Column(SmallInteger)
+    is_in_battle = Column(Boolean, default=False)
+    updated = Column(Integer,default=time,onupdate=time)
+    total_cp = Column(SmallInteger)
+
+    __table_args__ = (
+        UniqueConstraint(
+            'fort_id',
+            'last_modified',
+            name='fort_id_last_modified_unique'
+        ),
+    )
+
+class Raid(Base):
+    __tablename__ = 'raids'
+
+    id = Column(Integer, primary_key=True)
+    external_id = Column(BigInteger, unique=True)
+    fort_id = Column(Integer, ForeignKey('forts.id'))
+    level = Column(TINY_TYPE)
+    pokemon_id = Column(SmallInteger)
+    move_1 = Column(SmallInteger)
+    move_2 = Column(SmallInteger)
+    time_spawn = Column(Integer, index=True)
+    time_battle = Column(Integer)
+    time_end = Column(Integer)
+    cp = Column(Integer)
+
+class GymImage(Base):
+    __tablename__ = 'gym_images'
+    
+    id = Column(Integer, primary_key=True)
+    fort_id = Column(Integer)
+    param_1 = Column(Integer)
+    param_2 = Column(Integer)
+    param_3 = Column(Integer)
+    param_4 = Column(Integer)
+    param_5 = Column(Integer)
+    param_6 = Column(Integer)
+    created = Column(Integer,default=time)
+
+class PokemonImage(Base):
+    __tablename__ = 'pokemon_images'
+    
+    id = Column(Integer, primary_key=True)
+    pokemon_id = Column(Integer)
+    param_1 = Column(Integer)
+    param_2 = Column(Integer)
+    param_3 = Column(Integer)
+    param_4 = Column(Integer)
+    param_5 = Column(Integer)
+    param_6 = Column(Integer)
+    param_7 = Column(Integer)
+    created = Column(Integer,default=time)
+
+# create gym_images and pokemon_images table if non
+Base.metadata.create_all(bind=engine)
+Session = sessionmaker(bind=engine)
+
+def get_gym_images(session):
+    return session.query(GymImage)
+
+def get_pokemon_images(session):
+    return session.query(PokemonImage)
+
+unknown_fort_name = 'UNKNOWN FORT'
+def get_unknown_fort_id(session):
+    unknown_fort = session.query(Fort).filter_by(name=unknown_fort_name).first()
+    # Check UNKNOWN FORT existance if not, add
+    if unknown_fort is None:
+        session.add(Fort(name=unknown_fort_name))
+        session.commit()
+        unknown_fort = session.query(Fort).filter_by(name=unknown_fort_name).first()
+    return unknown_fort.id
+
+not_a_fort_name = 'NOT A FORT'
+def get_not_a_fort_id(session):
+    not_a_fort = session.query(Fort).filter_by(name=not_a_fort_name).first()
+    # Check NOT A FORT existance if not, add
+    if not_a_fort is None:
+        session.add(Fort(name=not_a_fort_name))
+        session.commit()
+        not_a_fort = session.query(Fort).filter_by(name=not_a_fort_name).first()
+    return not_a_fort.id
+
+def get_raid_battle_time(session, fort_id):
+    raid = session.query(Raid).filter(Raid.fort_id == str(fort_id)).first()
+    if raid is None:
+        session.add(Raid(fort_id = str(fort_id)))
+        session.commit()
+        raid = session.query(Raid).filter(Raid.fort_id == str(fort_id)).first()
+        raid.time_battle = 0
+    if raid.time_battle is None:
+        raid.time_battle = 0
+    return raid.time_battle
+
+def get_raid_pokemon_id(session, fort_id):
+    raid = session.query(Raid).filter(Raid.fort_id == str(fort_id)).first()
+    if raid is None:
+        session.add(Raid(fort_id = str(fort_id)))
+        session.commit()
+        raid = session.query(Raid).filter(Raid.fort_id == str(fort_id)).first()
+        raid.pokemon_id = -1
+    if raid.pokemon_id is None:
+        raid.pokemon_id = -1
+    return raid.pokemon_id
+    
+def update_raid_egg(session, fort_id, level, time_battle):
+    raid = session.query(Raid).filter_by(fort_id=str(fort_id)).first()
+    if raid is None:
+        session.add(Raid(fort_id = str(fort_id)))
+        session.commit()
+        raid = session.query(Raid).filter_by(fort_id=str(fort_id)).first()        
+    raid.level = int(level)
+    raid.pokemon_id = 0
+    raid.time_spawn = time_battle - 3600
+    raid.time_battle = time_battle
+    raid.time_end = time_battle + 2700
+    session.commit()
+
+def update_raid_mon(session, fort_id, pokemon_id):
+    raid = session.query(Raid).filter_by(fort_id=str(fort_id)).first()
+    if raid is None:
+        session.add(Raid(fort_id = str(fort_id)))
+        session.commit()
+        raid = session.query(Raid).filter_by(fort_id=str(fort_id)).first()        
+    raid.pokemon_id = int(pokemon_id)
+    session.commit()
+    
+def updata_fort_sighting(session, fort_id, unix_time):
+    fort_sighting = session.query(FortSighting).filter_by(fort_id=str(fort_id)).first()
+    if fort_sighting is None:
+        session.add(FortSighting(fort_id = str(fort_id), last_modified = int(unix_time), updated = int(unix_time)))
+        session.commit()
+        fort_sighting = session.query(FortSighting).filter_by(fort_id=str(fort_id)).first()            
+    fort_sighting.updated = int(unix_time)
+    fort_sighting.last_modified = int(unix_time)
+    session.commit()
+
+def add_gym_image(session,fort_id,top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2):
+    session.add(GymImage(fort_id=fort_id,param_1=top_mean0,param_2=top_mean1,param_3=top_mean2,param_4=left_mean0,param_5=left_mean1,param_6=left_mean2,created=int(datetime.datetime.now().timestamp())))
+    session.commit()
+
+def update_gym_image(session,gym_image_id,gym_image_fort_id):
+    gym_image = session.query(GymImage).filter_by(id=gym_image_id).first()
+    if gym_image is None:
+        print('No gym image found with id:', gym_image_fort_id)
+        return False
+    else:
+        gym_image.fort_id = gym_image_fort_id
+        session.commit()
+        print('gym image',gym_image_id,'is set to fort_id',gym_image_fort_id)
+        return True
+
+def add_pokemon_image(session,mon_id,mean1,mean2,mean3,mean4,mean5,mean6,mean7):
+    session.add(PokemonImage(pokemon_id=mon_id,param_1=mean1,param_2=mean2,param_3=mean3,param_4=mean4,param_5=mean5,param_6=mean6,param_7=mean7,created=int(datetime.datetime.now().timestamp())))
+    session.commit()
+
+def update_pokemon_image(session,pokemon_image_id, pokemon_id):
+    pokemon_image = session.query(PokemonImage).filter_by(id=pokemon_image_id).first()
+    if pokemon_image is None:
+        print('No pokemon image found with id:', pokemon_image_id)
+        return False
+    else:
+        pokemon_image.pokemon_id = pokemon_id
+        session.commit()
+        print('pokemon image',pokemon_image_id,'is set to pokemon_id',pokemon_id)
+        return True        
+
+def get_gym_image_id(session,top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2):
+    gym_image = session.query(GymImage).filter_by(param_1=top_mean0,param_2=top_mean1,param_3=top_mean2,param_4=left_mean0,param_5=left_mean1,param_6=left_mean2).first()
+    if gym_image is None:
+        unknown_fort_id = get_unknown_fort_id(session)
+        add_gym_image(session,unknown_fort_id,top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2)
+        gym_image = session.query(GymImage).filter_by(param_1=top_mean0,param_2=top_mean1,param_3=top_mean2,param_4=left_mean0,param_5=left_mean1,param_6=left_mean2).first()
+    return gym_image.id
+
+def get_gym_image_fort_id(session, gym_image_id):
+    gym_image = session.query(GymImage).filter_by(id=gym_image_id).first()
+    if gym_image is None:
+        return None
+    else:
+        return gym_image.fort_id
+
+def get_pokemon_image_id(session,mean1_in,mean2_in,mean3_in,mean4_in,mean5_in,mean6_in,mean7_in):
+    pokemon_image = session.query(PokemonImage).filter_by(param_1=mean1_in,param_2=mean2_in,param_3=mean3_in,param_4=mean4_in,param_5=mean5_in,param_6=mean6_in,param_7=mean7_in).first()
+    if pokemon_image is None:
+        add_pokemon_image(session,0,mean1_in,mean2_in,mean3_in,mean4_in,mean5_in,mean6_in,mean7_in)
+        pokemon_image = session.query(PokemonImage).filter_by(param_1=mean1_in,param_2=mean2_in,param_3=mean3_in,param_4=mean4_in,param_5=mean5_in,param_6=mean6_in,param_7=mean7_in).first()
+    return pokemon_image.id
+
+def get_pokemon_image_pokemon_id(session, pokemon_image_id):
+    pokemon_image = session.query(PokemonImage).filter_by(id=pokemon_image_id).first()
+    if pokemon_image is None:
+        return None
+    else:
+        return pokemon_image.pokemon_id
+
+def get_forts(session):
+    return session.query(Fort).all()
+

--- a/Backend/database.py
+++ b/Backend/database.py
@@ -11,8 +11,10 @@ from sqlalchemy.orm import sessionmaker, relationship, eagerload, foreign, remot
 from sqlalchemy.types import TypeDecorator, Numeric, Text, TIMESTAMP
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm.exc import NoResultFound
-
 from config import DB_ENGINE
+from logging import basicConfig, getLogger, FileHandler, StreamHandler, DEBUG, INFO, ERROR, Formatter
+
+LOG = getLogger('')
 
 if DB_ENGINE.startswith('mysql'):
     from sqlalchemy.dialects.mysql import TINYINT, MEDIUMINT, BIGINT, DOUBLE, LONGTEXT
@@ -253,12 +255,12 @@ def add_gym_image(session,fort_id,top_mean0,top_mean1,top_mean2,left_mean0,left_
 def update_gym_image(session,gym_image_id,gym_image_fort_id):
     gym_image = session.query(GymImage).filter_by(id=gym_image_id).first()
     if gym_image is None:
-        print('No gym image found with id:', gym_image_fort_id)
+        LOG.info('No gym image found with id:{}'.format(gym_image_fort_id))
         return False
     else:
         gym_image.fort_id = gym_image_fort_id
         session.commit()
-        print('gym image',gym_image_id,'is set to fort_id',gym_image_fort_id)
+        LOG.info('gym image {} is set to fort_id {}'.format(gym_image_id,gym_image_fort_id))
         return True
 
 def add_pokemon_image(session,mon_id,mean1,mean2,mean3,mean4,mean5,mean6,mean7):
@@ -268,12 +270,12 @@ def add_pokemon_image(session,mon_id,mean1,mean2,mean3,mean4,mean5,mean6,mean7):
 def update_pokemon_image(session,pokemon_image_id, pokemon_id):
     pokemon_image = session.query(PokemonImage).filter_by(id=pokemon_image_id).first()
     if pokemon_image is None:
-        print('No pokemon image found with id:', pokemon_image_id)
+        LOG.info('No pokemon image found with id: {}'.format(pokemon_image_id))
         return False
     else:
         pokemon_image.pokemon_id = pokemon_id
         session.commit()
-        print('pokemon image',pokemon_image_id,'is set to pokemon_id',pokemon_id)
+        LOG.info('pokemon image {} is set to pokemon_id {}'.format(pokemon_image_id,pokemon_id))
         return True        
 
 def get_gym_image_id(session,top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2):

--- a/Backend/downloadfortimg.py
+++ b/Backend/downloadfortimg.py
@@ -3,34 +3,64 @@ import requests
 import shutil
 import database
 import os
+import time
+from config import MAP_START, MAP_END
 
 url_image_path = os.getcwd() + '/url_img/'
 
 session = database.Session()
 
 def download_img(url, file_name):
-    try:
-        r = requests.get(url, stream=True)
-        if r.status_code == 200:
-            with open(file_name, 'wb') as f:
-                r.raw.decode_content = True
-                shutil.copyfileobj(r.raw, f)
-    except KeyboardInterrupt:
-        print('Ctrl-C interrupted')
-        session.close()
-        sys.exit(1)
-    except:
-        print('Download error', url) 
+    retry = 1
+    while retry <= 5:
+        try:
+            r = requests.get(url, stream=True, timeout=5)
+            if r.status_code == 200:
+                with open(file_name, 'wb') as f:
+                    r.raw.decode_content = True
+                    shutil.copyfileobj(r.raw, f)
+                break
+        except KeyboardInterrupt:
+            print('Ctrl-C interrupted')
+            session.close()
+            sys.exit(1)
+        except:
+            retry=retry+1
+            print('Download error', url)
+            if retry <= 5:
+                print('retry:', retry)
+            else:
+                print('Failed to download after 5 retry')
 
 def main():
+    check_boundary = True
+    if (MAP_START[0] == 0 and MAP_START[1] == 0) or (MAP_END[0] == 0 and MAP_END[1] == 0):
+        check_boundary = False
+    else:
+        north = max(MAP_START[0], MAP_END[0])
+        south = min(MAP_START[0], MAP_END[0])
+        east = max(MAP_START[1], MAP_END[1])
+        west = min(MAP_START[1], MAP_END[1])
+        
     file_path = os.path.dirname(url_image_path)
     if not os.path.exists(file_path):
         os.makedirs(file_path)    
     for fort in database.get_forts(session):
         if fort.url is not None:
-            filename = url_image_path + str(fort.id) + '.jpg'
-            print('Downloading', filename)
-            download_img(str(fort.url), str(filename))
+            in_boundary = True
+            if check_boundary == True:
+                lat_check = (fort.lat-north)*(fort.lat-south)
+                lon_check = (fort.lon-east)*(fort.lon-west)
+#                print(lat_check, lon_check)
+                if lat_check<=0.0 and lon_check<=0.0:
+                    in_boundary = True
+                else:
+                    in_boundary = False
+            if in_boundary == True:
+                filename = url_image_path + str(fort.id) + '.jpg'
+                print('Downloading', filename)
+                download_img(str(fort.url), str(filename))
+#                time.sleep(0.2)
     session.close()
 
 if __name__ == '__main__':

--- a/Backend/downloadfortimg.py
+++ b/Backend/downloadfortimg.py
@@ -1,0 +1,38 @@
+import sys
+import requests
+import shutil
+import database
+import os
+
+url_image_path = os.getcwd() + '/url_img/'
+
+session = database.Session()
+
+def download_img(url, file_name):
+    try:
+        r = requests.get(url, stream=True)
+        if r.status_code == 200:
+            with open(file_name, 'wb') as f:
+                r.raw.decode_content = True
+                shutil.copyfileobj(r.raw, f)
+    except KeyboardInterrupt:
+        print('Ctrl-C interrupted')
+        session.close()
+        sys.exit(1)
+    except:
+        print('Download error', url) 
+
+def main():
+    file_path = os.path.dirname(url_image_path)
+    if not os.path.exists(file_path):
+        os.makedirs(file_path)    
+    for fort in database.get_forts(session):
+        if fort.url is not None:
+            filename = url_image_path + str(fort.id) + '.jpg'
+            print('Downloading', filename)
+            download_img(str(fort.url), str(filename))
+    session.close()
+
+if __name__ == '__main__':
+    main()
+

--- a/Backend/findfort.py
+++ b/Backend/findfort.py
@@ -71,7 +71,7 @@ def findfort_main():
                 except:
                     LOG.error('Matching error')
             LOG.info('fort_filename:{} max_fort_id: {} max_value: {}'.format(fort_filename,max_fort_id, max_value))
-            if float(max_value) >= 0.90:
+            if float(max_value) >= 0.85:
                 img = cv2.imread(str(fort_fullpath_filename),3)
                 gym_image_id = rs.get_gym_image_id(img)
                 gym_image_fort_id = db.get_gym_image_fort_id(session, gym_image_id)
@@ -91,7 +91,7 @@ def findfort_main():
                 shutil.move(fort_fullpath_filename, fort_result_file)
                 shutil.copy(max_url_fullpath_filename, url_result_file)
                 LOG.info('Successfully found fort id: {}'.format(max_fort_id))
-            elif float(max_value) >= 0.85:
+            elif float(max_value) >= 0.80:
                 fort_result_file = os.getcwd() + '/need_check_img/Fort_' + str(max_fort_id) + '.png'
                 url_result_file = os.getcwd() + '/need_check_img/Fort_'+str(max_fort_id) + '_url.jpg'
                 shutil.move(fort_fullpath_filename, fort_result_file)

--- a/Backend/findfort.py
+++ b/Backend/findfort.py
@@ -50,7 +50,7 @@ def findfort_main():
         max_fort_id = 0
         max_url_fullpath_filename = ''
         new_img_count = 0
-        for fort_fullpath_filename in p.glob('*.png'):
+        for fort_fullpath_filename in p.glob('GymImage*.png'):
             new_img_count = new_img_count+1
             fort_filename = os.path.basename(fort_fullpath_filename)
             max_fort_id = 0
@@ -86,7 +86,7 @@ def findfort_main():
                 fort_result_file = os.getcwd() + '/success_img/Fort_' + str(max_fort_id) + '.png'
                 url_result_file = os.getcwd() + '/success_img/Fort_'+str(max_fort_id) + '_url.jpg'
                 shutil.move(fort_fullpath_filename, fort_result_file)
-                shutil.move(max_url_fullpath_filename, url_result_file)
+                shutil.copy(max_url_fullpath_filename, url_result_file)
                 print('Successfully found fort id:', max_fort_id)
             elif float(max_value) >= 0.85:
                 fort_result_file = os.getcwd() + '/need_check_img/Fort_' + str(max_fort_id) + '.png'

--- a/Backend/findfort.py
+++ b/Backend/findfort.py
@@ -1,0 +1,118 @@
+import sys
+import cv2
+import numpy as np
+from pathlib import Path
+import os
+import shutil
+import matching as mt
+import database as db
+import raidscan as rs
+import time
+
+unknown_image_path = os.getcwd() + '/unknown_img'
+url_image_path = os.getcwd() + '/url_img'
+
+success_img_path = os.getcwd() + '/success_img/'
+need_check_img_path = os.getcwd() + '/need_check_img/'
+not_find_img_pth = os.getcwd() + '/not_find_img/'
+
+def findfort_main():
+    # Check directories 
+    file_path = os.path.dirname(unknown_image_path+'/')
+    if not os.path.exists(file_path):
+        print('Cannot find unknow_img directory. Run raidscan.py to create the directory')    
+        return
+
+    file_path = os.path.dirname(url_image_path+'/')
+    if not os.path.exists(file_path):
+        print('Cannot find url_img directory. Run downloadfortimg.py')
+        print('to create the directory and download fort images')
+        return
+
+    # Create directories if not exists
+    file_path = os.path.dirname(success_img_path)
+    if not os.path.exists(file_path):
+        os.makedirs(file_path)
+    file_path = os.path.dirname(need_check_img_path)
+    if not os.path.exists(file_path):
+        os.makedirs(file_path)
+    file_path = os.path.dirname(not_find_img_pth)
+    if not os.path.exists(file_path):
+        os.makedirs(file_path)
+    
+    p = Path(unknown_image_path)
+    p_url = Path(url_image_path)
+
+    while True:
+        print('Run find fort task')
+        session = db.Session()
+        max_value = 0.0
+        max_fort_id = 0
+        max_url_fullpath_filename = ''
+        new_img_count = 0
+        for fort_fullpath_filename in p.glob('*.png'):
+            new_img_count = new_img_count+1
+            fort_filename = os.path.basename(fort_fullpath_filename)
+            max_fort_id = 0
+            max_value = 0.0 
+            for url_fullpath_filename in p_url.glob('*.jpg'):
+                try:
+                    result = mt.fort_image_matching(str(url_fullpath_filename), str(fort_fullpath_filename))
+                    url_filename = os.path.basename(url_fullpath_filename)
+                    fort_id, ext = os.path.splitext(url_filename)            
+        #            print('fort_id:',fort_id,'result:',result,'max_value:',max_value, 'max_fort_id:', max_fort_id)
+                    if result >= max_value:
+                        max_value = result
+                        max_fort_id = fort_id
+                        max_url_fullpath_filename = url_fullpath_filename
+                except:
+                    print('Matching error')
+            print('fort_filename:',fort_filename, 'max_fort_id:',max_fort_id,'max_value:', max_value)
+            if float(max_value) >= 0.90:
+                img = cv2.imread(str(fort_fullpath_filename),3)
+                gym_image_id = rs.get_gym_image_id(img)
+                gym_image_fort_id = db.get_gym_image_fort_id(session, gym_image_id)
+                if int(max_fort_id) == int(gym_image_fort_id):
+                    print('This gym image is already trained')
+                else:
+                    unknown_fort_id = db.get_unknown_fort_id(session)
+                    print('gym_images id:',gym_image_id,'fort_id:', gym_image_fort_id,'unknow_fort_id:',unknown_fort_id)
+                    if gym_image_fort_id == unknown_fort_id:
+                        db.update_gym_image(session,gym_image_id,max_fort_id)
+                    else:
+                        print('The gym image is assigned as fort id:', gym_image_fort_id)
+                        print('If the fort id is not correct, delete the gym image id:', gym_image_id)
+                        print('and run submit.py again')       
+                fort_result_file = os.getcwd() + '/success_img/Fort_' + str(max_fort_id) + '.png'
+                url_result_file = os.getcwd() + '/success_img/Fort_'+str(max_fort_id) + '_url.jpg'
+                shutil.move(fort_fullpath_filename, fort_result_file)
+                shutil.move(max_url_fullpath_filename, url_result_file)
+                print('Successfully found fort id:', max_fort_id)
+            elif float(max_value) >= 0.85:
+                fort_result_file = os.getcwd() + '/need_check_img/Fort_' + str(max_fort_id) + '.png'
+                url_result_file = os.getcwd() + '/need_check_img/Fort_'+str(max_fort_id) + '_url.jpg'
+                shutil.move(fort_fullpath_filename, fort_result_file)
+                shutil.copy(max_url_fullpath_filename, url_result_file)
+                print('Found fort id:', max_fort_id, ', but need to verify')
+            else:
+                fort_result_file = os.getcwd() + '/not_find_img/' + str(fort_filename)
+                url_result_file = os.getcwd() + '/not_find_img/'+str(max_fort_id) + '.jpg'
+                shutil.move(fort_fullpath_filename, fort_result_file)
+                shutil.copy(max_url_fullpath_filename, url_result_file)
+                print('Can not find fort:', max_fort_id, ', check the image in not_find_img')
+
+        print(new_img_count, 'new fort image processed')
+        session.close()
+        time.sleep(30) # task runs every 10 seconds
+
+    print('Done')
+    return
+    
+if __name__ == '__main__':
+    findfort_main()
+
+                    
+                    
+                    
+            
+                

--- a/Backend/findfort.py
+++ b/Backend/findfort.py
@@ -100,7 +100,7 @@ def findfort_main():
             else:
                 fort_result_file = os.getcwd() + '/not_find_img/' + str(fort_filename)
                 url_result_file = os.getcwd() + '/not_find_img/'+str(max_fort_id) + '.jpg'
-                shutil.move(fort_fullpath_filename, fort_result_file)p
+                shutil.move(fort_fullpath_filename, fort_result_file)
                 shutil.copy(max_url_fullpath_filename, url_result_file)
                 LOG.info('Can not find fort: {}, check the image in not_find_img'.format(max_fort_id))
 

--- a/Backend/manualsubmit.py
+++ b/Backend/manualsubmit.py
@@ -1,0 +1,93 @@
+import cv2
+import numpy as np
+from pathlib import Path
+import os
+import shutil
+import database as db
+import raidscan as rs
+
+session = db.Session()
+
+training_image_path = os.getcwd() + '/not_find_img'
+p = Path(training_image_path)
+
+url_image_path = os.getcwd() + '/url_img/'
+
+print('***************************************************')
+print('File name formating')
+print('Submit Gym image the name format is')
+print('    Fort_FortId.png. Example: Fort_110.png')
+print('    Not valid fort image    : Fort_Not_xx.png')
+print('Submit Pokemon image the name format is')
+print('    Pokemon_PokemonId.png. Example: Pokemon_110.png')
+print('***************************************************')
+
+fort_count = 0
+pokemon_count = 0
+
+for fullpath_filename in p.glob('*.png'):
+    filename = os.path.basename(fullpath_filename)
+    print('Read', filename)
+    image_name = filename.split('_')
+    if image_name[0] == 'Fort':
+        fort_id, ext = os.path.splitext(image_name[1])
+        if fort_id.isdecimal()==True:
+            print('fort_id:', fort_id)
+            img = cv2.imread(str(fullpath_filename),3)
+            gym_image_id = rs.get_gym_image_id(img)
+            gym_image_fort_id = db.get_gym_image_fort_id(session, gym_image_id)
+            if int(fort_id) == int(gym_image_fort_id):
+                print('This gym image is already trained')
+                os.remove(fullpath_filename)
+            else:
+                unknown_fort_id = db.get_unknown_fort_id(session)
+                print('gym_images id:',gym_image_id,'fort_id:', gym_image_fort_id,'unknow_fort_id:',unknown_fort_id)
+                if gym_image_fort_id == unknown_fort_id:
+                    if db.update_gym_image(session,gym_image_id,fort_id) == True:
+                        fort_result_file = os.getcwd() + '/success_img/Fort_' + str(fort_id) + '.png'
+                        url_result_file = os.getcwd() + '/success_img/Fort_'+str(fort_id) + '_url.jpg'
+                        url_org_file = os.getcwd() + '/url_img/'+str(fort_id) + '.jpg'
+                        shutil.move(fullpath_filename, fort_result_file)
+                        shutil.copy(url_org_file, fort_result_file)
+                        fort_count = fort_count+1
+                else:
+                    print('The gym image is assigned as fort id:', gym_image_fort_id)
+                    print('If the fort id is not correct, delete the gym image id:', gym_image_id)
+                    print('and run submit.py again')
+        elif str(fort_id) == 'Not':
+            img = cv2.imread(str(fullpath_filename),3)
+            gym_image_id = rs.get_gym_image_id(img)
+            not_fort_id = db.get_not_a_fort_id(session)
+            if db.update_gym_image(session,gym_image_id,not_fort_id) == True:
+                fort_dest_file = os.getcwd() + '/not_valid_img/not_valid_' + str(gym_image_id) + '.png'
+                shutil.move(fullpath_filename, fort_dest_file)
+                print('gym image id:', gym_image_id, 'is set as not valid')
+            
+    elif image_name[0] == 'Pokemon':
+        pokemon_id, ext = os.path.splitext(image_name[1])
+        if pokemon_id.isdecimal()==True:
+            print('pokemon_id:', pokemon_id)
+            img = cv2.imread(str(fullpath_filename),3)
+            pokemon_image_id = rs.get_pokemon_image_id(img)
+            pokemon_image_pokemon_id = db.get_pokemon_image_pokemon_id(session, pokemon_image_id)
+            if int(pokemon_id) == int(pokemon_image_pokemon_id):
+                print('This pokemon image is already trained')
+                os.remove(fullpath_filename)
+            else:
+                if int(pokemon_image_pokemon_id) == 0:
+                    if db.update_pokemon_image(session,pokemon_image_id,pokemon_id)==True:
+                        os.remove(fullpath_filename)
+                        pokemon_count = pokemon_count +1
+                else:
+                    print('The pokemon image is assigned as pokemon id:', pokemon_image_pokemon_id)
+                    print('If the pokemon id is not correct, delete the pokemon image id:', pokemon_image_id)
+                    print('and run raidsubmit.py again')
+
+print('Submitted')
+print('  ',fort_count,'gym images')
+print('  ',pokemon_count,'pokemon images')
+                    
+                    
+                    
+            
+                

--- a/Backend/matching.py
+++ b/Backend/matching.py
@@ -11,13 +11,12 @@ def fort_image_matching(url_img_name, fort_img_name):
         scale = float(288/height)
     else:
         scale = float(288/width)
-
+        
     height_f, width_f, channels_f = fort_img.shape
 
     scale_fort = width_f/320
         
-    if scale < 0.98 or scale > 1.02:
-        url_img = cv2.resize(url_img,None,fx=scale*scale_fort, fy=scale*scale_fort, interpolation = cv2.INTER_NEAREST)
+    url_img = cv2.resize(url_img,None,fx=scale*scale_fort, fy=scale*scale_fort, interpolation = cv2.INTER_NEAREST)
 
     crop = fort_img[int(74*scale_fort):int(246*scale_fort),int(74*scale_fort):int(144*scale_fort)]
 
@@ -30,14 +29,14 @@ def fort_image_matching(url_img_name, fort_img_name):
 
     result = cv2.matchTemplate(url_img, crop, cv2.TM_CCOEFF_NORMED)
     min_val3, max_val3, min_loc3, max_loc3 = cv2.minMaxLoc(result)
-
-    # Calculate x y distance between max_loc3 and center of url_img
-    height, width, channels = url_img.shape    
+    
+    height, width, channels = url_img.shape
+    
     ui_center_x = width/2-max_loc3[0]
     ui_center_y = height/2-max_loc3[1]
-    
+ 
     dif_x = abs(ui_center_x - fi_center_x)
-    dif_y = abs(ui_center_y - fi_center_y)
+    dif_y = abs(ui_center_y - fi_center_y) 
     
     if dif_x > 5 or dif_y >5:
         return 0.0
@@ -59,8 +58,7 @@ def fort_image_matching_imshow(url_img_name, fort_img_name):
 
     scale_fort = width_f/320
         
-    if scale < 0.98 or scale > 1.02:
-        url_img = cv2.resize(url_img,None,fx=scale*scale_fort, fy=scale*scale_fort, interpolation = cv2.INTER_NEAREST)
+    url_img = cv2.resize(url_img,None,fx=scale*scale_fort, fy=scale*scale_fort, interpolation = cv2.INTER_NEAREST)
 
     crop = fort_img[int(74*scale_fort):int(246*scale_fort),int(74*scale_fort):int(144*scale_fort)]
 
@@ -87,7 +85,7 @@ def fort_image_matching_imshow(url_img_name, fort_img_name):
     height, width, channels = crop.shape
     bottom_right = (top_left[0] + width, top_left[1] + height)
     cv2.rectangle(url_img,top_left, bottom_right, (0, 255, 0), 2)
-    cv2.rectangle(fort_img,(74,74), (144, 246), (0, 0, 255), 2)
+    cv2.rectangle(fort_img,(int(74*scale_fort),int(74*scale_fort)), (int(144*scale_fort), int(246*scale_fort)), (0, 0, 255), 2)
 
     cv2.imshow('matching result', url_img)
     cv2.imshow('crop', crop)
@@ -100,7 +98,7 @@ def fort_image_matching_imshow(url_img_name, fort_img_name):
 
 
 if __name__ == '__main__':
-    fort_id = 432
+    fort_id = 1
     url_img_path = os.getcwd() + '/success_img/Fort_' + str(fort_id) + '_url.jpg'
     fort_img_path = os.getcwd() + '/success_img/Fort_' + str(fort_id) + '.png'
     print(url_img_path)

--- a/Backend/matching.py
+++ b/Backend/matching.py
@@ -11,15 +11,19 @@ def fort_image_matching(url_img_name, fort_img_name):
         scale = float(288/height)
     else:
         scale = float(288/width)
+
+    height_f, width_f, channels_f = fort_img.shape
+
+    scale_fort = width_f/320
         
     if scale < 0.98 or scale > 1.02:
-        url_img = cv2.resize(url_img,None,fx=scale, fy=scale, interpolation = cv2.INTER_NEAREST)
+        url_img = cv2.resize(url_img,None,fx=scale*scale_fort, fy=scale*scale_fort, interpolation = cv2.INTER_NEAREST)
 
-    crop = fort_img[74:246,74:144]
+    crop = fort_img[int(74*scale_fort):int(246*scale_fort),int(74*scale_fort):int(144*scale_fort)]
 
     # Calculate center of fort image(x=74, y=74, width=172, height=172) of fort_img
-    fi_center_x = (246-74)/2
-    fi_center_y = (246-74)/2
+    fi_center_x = ((246-74)*scale_fort)/2
+    fi_center_y = ((246-74)*scale_fort)/2
 
     if crop.mean() == 255 or crop.mean() == 0:
         return 0.0
@@ -51,14 +55,18 @@ def fort_image_matching_imshow(url_img_name, fort_img_name):
     else:
         scale = float(288/width)
         
-    if scale < 0.98 or scale > 1.02:
-        url_img = cv2.resize(url_img,None,fx=scale, fy=scale, interpolation = cv2.INTER_NEAREST)
+    height_f, width_f, channels_f = fort_img.shape
 
-    #crop = fort_img[74:246,74:246]
-    crop = fort_img[74:246,74:144]
-    
-    fi_center_x = (246-74)/2
-    fi_center_y = (246-74)/2
+    scale_fort = width_f/320
+        
+    if scale < 0.98 or scale > 1.02:
+        url_img = cv2.resize(url_img,None,fx=scale*scale_fort, fy=scale*scale_fort, interpolation = cv2.INTER_NEAREST)
+
+    crop = fort_img[int(74*scale_fort):int(246*scale_fort),int(74*scale_fort):int(144*scale_fort)]
+
+    # Calculate center of fort image(x=74, y=74, width=172, height=172) of fort_img
+    fi_center_x = ((246-74)*scale_fort)/2
+    fi_center_y = ((246-74)*scale_fort)/2
 
     if crop.mean() == 255 or crop.mean() == 0:
         return 0.0
@@ -66,7 +74,6 @@ def fort_image_matching_imshow(url_img_name, fort_img_name):
     result = cv2.matchTemplate(url_img, crop, cv2.TM_CCOEFF_NORMED)
     min_val3, max_val3, min_loc3, max_loc3 = cv2.minMaxLoc(result)
     
-
     height, width, channels = url_img.shape
     
     ui_center_x = width/2-max_loc3[0]

--- a/Backend/matching.py
+++ b/Backend/matching.py
@@ -83,7 +83,6 @@ def fort_image_matching_imshow(url_img_name, fort_img_name):
     cv2.rectangle(fort_img,(74,74), (144, 246), (0, 0, 255), 2)
 
     cv2.imshow('matching result', url_img)
-#    cv2.imshow('tmp', fort_img)
     cv2.imshow('crop', crop)
     cv2.waitKey(0)
 
@@ -100,7 +99,4 @@ if __name__ == '__main__':
     print(url_img_path)
     print(fort_img_path)
     print(fort_image_matching_imshow(url_img_path,fort_img_path))
-#    print(fort_image_matching('/home/mizu/raidimage/GymMonDetectionPostgres/url_image/1.jpg','/home/mizu/raidimage/GymMonDetectionPostgres/Training/GymImage_82.png'))
-#    print(fort_image_matching_imshow('/Users/akira/raidimage/GymMonDetectionPostgres/success_img/Fort_103_url.jpg','/Users/akira/raidimage/GymMonDetectionPostgres/success_img/Fort_103.png'))
-
 

--- a/Backend/matching.py
+++ b/Backend/matching.py
@@ -1,0 +1,106 @@
+import cv2
+import os
+
+def fort_image_matching(url_img_name, fort_img_name):
+    url_img = cv2.imread(url_img_name,3)
+    fort_img = cv2.imread(fort_img_name,3)
+
+    height, width, channels = url_img.shape
+    
+    if width > height:
+        scale = float(288/height)
+    else:
+        scale = float(288/width)
+        
+    if scale < 0.98 or scale > 1.02:
+        url_img = cv2.resize(url_img,None,fx=scale, fy=scale, interpolation = cv2.INTER_NEAREST)
+
+    crop = fort_img[74:246,74:144]
+
+    # Calculate center of fort image(x=74, y=74, width=172, height=172) of fort_img
+    fi_center_x = (246-74)/2
+    fi_center_y = (246-74)/2
+
+    if crop.mean() == 255 or crop.mean() == 0:
+        return 0.0
+
+    result = cv2.matchTemplate(url_img, crop, cv2.TM_CCOEFF_NORMED)
+    min_val3, max_val3, min_loc3, max_loc3 = cv2.minMaxLoc(result)
+
+    # Calculate x y distance between max_loc3 and center of url_img
+    height, width, channels = url_img.shape    
+    ui_center_x = width/2-max_loc3[0]
+    ui_center_y = height/2-max_loc3[1]
+    
+    dif_x = abs(ui_center_x - fi_center_x)
+    dif_y = abs(ui_center_y - fi_center_y)
+    
+    if dif_x > 5 or dif_y >5:
+        return 0.0
+
+    return max_val3
+
+def fort_image_matching_imshow(url_img_name, fort_img_name):
+    url_img = cv2.imread(url_img_name,3)
+    fort_img = cv2.imread(fort_img_name,3)
+
+    height, width, channels = url_img.shape
+    
+    if width > height:
+        scale = float(288/height)
+    else:
+        scale = float(288/width)
+        
+    if scale < 0.98 or scale > 1.02:
+        url_img = cv2.resize(url_img,None,fx=scale, fy=scale, interpolation = cv2.INTER_NEAREST)
+
+    #crop = fort_img[74:246,74:246]
+    crop = fort_img[74:246,74:144]
+    
+    fi_center_x = (246-74)/2
+    fi_center_y = (246-74)/2
+
+    if crop.mean() == 255 or crop.mean() == 0:
+        return 0.0
+
+    result = cv2.matchTemplate(url_img, crop, cv2.TM_CCOEFF_NORMED)
+    min_val3, max_val3, min_loc3, max_loc3 = cv2.minMaxLoc(result)
+    
+
+    height, width, channels = url_img.shape
+    
+    ui_center_x = width/2-max_loc3[0]
+    ui_center_y = height/2-max_loc3[1]
+ 
+    dif_x = abs(ui_center_x - fi_center_x)
+    dif_y = abs(ui_center_y - fi_center_y)    
+    print(dif_x, dif_y)
+    
+    top_left = max_loc3
+    height, width, channels = crop.shape
+    bottom_right = (top_left[0] + width, top_left[1] + height)
+    cv2.rectangle(url_img,top_left, bottom_right, (0, 255, 0), 2)
+    cv2.rectangle(fort_img,(74,74), (144, 246), (0, 0, 255), 2)
+
+    cv2.imshow('matching result', url_img)
+#    cv2.imshow('tmp', fort_img)
+    cv2.imshow('crop', crop)
+    cv2.waitKey(0)
+
+    if dif_x > 5 or dif_y >5:
+        return 0.0   
+
+    return max_val3
+
+
+if __name__ == '__main__':
+    fort_id = 432
+    url_img_path = os.getcwd() + '/success_img/Fort_' + str(fort_id) + '_url.jpg'
+    fort_img_path = os.getcwd() + '/success_img/Fort_' + str(fort_id) + '.png'
+    print(url_img_path)
+    print(fort_img_path)
+    print(fort_image_matching_imshow(url_img_path,fort_img_path))
+#    print(fort_image_matching('/home/mizu/raidimage/GymMonDetectionPostgres/url_image/1.jpg','/home/mizu/raidimage/GymMonDetectionPostgres/Training/GymImage_82.png'))
+#    print(fort_image_matching_imshow('/Users/akira/raidimage/GymMonDetectionPostgres/success_img/Fort_103_url.jpg','/Users/akira/raidimage/GymMonDetectionPostgres/success_img/Fort_103.png'))
+
+

--- a/Backend/raidscan.py
+++ b/Backend/raidscan.py
@@ -1,0 +1,415 @@
+import sys
+import cv2
+import numpy as np
+from pathlib import Path
+import os
+import time
+import math
+import shutil
+from PIL import Image
+import pytesseract
+import csv
+import datetime
+import time
+import database
+
+process_img_path = os.getcwd() + '/process_img/'
+copy_path = os.getcwd() + '/unknown_img/'
+
+# Create directories if not exists
+file_path = os.path.dirname(process_img_path)
+if not os.path.exists(file_path):
+    print('process_img directory created')
+    os.makedirs(file_path)
+
+file_path = os.path.dirname(copy_path)
+if not os.path.exists(file_path):
+    print('unknown_img directory created')
+    os.makedirs(file_path)
+
+p = Path(process_img_path)
+
+timefile = "time.png"
+level1_num = 328950.0
+
+session = database.Session()
+
+gym_db = [gym for gym in database.get_gym_images(session)]
+print(len(gym_db),'gym images loaded')
+#for gym in gym_db:
+#    print(gym.id, gym.fort_id, gym.param_1, gym.param_2, gym.param_3, gym.param_4, gym.param_5, gym.param_6)
+
+mon_db = [mon for mon in database.get_pokemon_images(session)]
+print(len(mon_db),'pokemon images loaded')
+
+unknown_fort_id = database.get_unknown_fort_id(session)
+not_a_fort_id = database.get_not_a_fort_id(session)
+
+# Detect level of raid from level image
+def detectLevel(level_img):
+    img_gray = cv2.cvtColor(level_img,cv2.COLOR_BGR2GRAY)
+    ret,thresh1 = cv2.threshold(img_gray,240,255,cv2.THRESH_BINARY_INV)
+    level = int(cv2.sumElems(thresh1)[0]/level1_num + 0.2)
+#    cv2.imshow('level', thresh1)
+#    cv2.waitKey(0)
+    return level
+
+# Detect hatch time from time image
+def detectTime(time_img):
+    img_gray = cv2.cvtColor(time_img,cv2.COLOR_BGR2GRAY)
+    ret,thresh1 = cv2.threshold(img_gray,240,255,cv2.THRESH_BINARY_INV)
+    cv2.imwrite(timefile, thresh1)
+    text = pytesseract.image_to_string(Image.open(timefile))
+    os.remove(timefile)
+#    cv2.imshow('time', thresh1)
+#    cv2.waitKey(0)
+    return text
+
+# Detect gym from raid sighting image
+def detectGym(raid_img):
+    global gym_db
+    
+    height, width, channels = raid_img.shape
+    if width == 320 and height == 525: 
+        cropTop = raid_img[40:70, 135:185]
+        cropLeft = raid_img[125:195, 45:70]
+    else:
+        print('Unsuported image size')
+        session.close()
+        sys.exit(1)
+        return -1
+            
+    top_mean0 = int(cropTop[:,:,0].mean())
+    top_mean1 = int(cropTop[:,:,1].mean())
+    top_mean2 = int(cropTop[:,:,2].mean())
+    left_mean0 = int(cropLeft[:,:,0].mean())
+    left_mean1 = int(cropLeft[:,:,1].mean())
+    left_mean2 = int(cropLeft[:,:,2].mean())
+
+    min_error = 10000000
+    gym_id = 0
+    gym_image_id = 0
+
+    print('Gyms in gym_images:',len(gym_db))
+#    print(top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2)
+
+    for gym in gym_db:
+        dif1 = pow(top_mean0 - gym.param_1,2)
+        dif2 = pow(top_mean1 - gym.param_2,2)
+        dif3 = pow(top_mean2 - gym.param_3,2)
+        dif4 = pow(left_mean0 - gym.param_4,2)
+        dif5 = pow(left_mean1 - gym.param_5,2)
+        dif6 = pow(left_mean2 - gym.param_6,2)
+        error = math.sqrt(dif1+dif2+dif3+dif4+dif5+dif6)
+#        print(gym.fort_id,error,gym.param_1,gym.param_2,gym.param_3,gym.param_4,gym.param_5,gym.param_6)
+        # find minimum error
+        if error < min_error:
+            min_error = error
+            gym_id = gym.fort_id
+            gym_image_id = gym.id
+
+    if min_error > 10:
+        print(gym_id, min_error)
+        print('GymImage added to database')
+        gym_id = -1
+        database.add_gym_image(session,unknown_fort_id,top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2)
+        gym_image_id = database.get_gym_image_id(session,top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2)
+        print('GymImage reloaded')
+        # Reload gym_images
+        gym_db = [ gym for gym in database.get_gym_images(session)]
+#        for gym in gym_db:
+#            print(gym.id, gym.fort_id, gym.param_1, gym.param_2, gym.param_3, gym.param_4, gym.param_5, gym.param_6)
+        
+    return gym_image_id, gym_id, min_error
+
+def get_gym_image_id(raid_img):
+    height, width, channels = raid_img.shape
+    if width == 320 and height == 525: 
+        cropTop = raid_img[40:70, 135:185]
+        cropLeft = raid_img[125:195, 45:70]
+    else:
+        print('Unsuported image size')
+        session.close()
+        sys.exit(1)
+        return -1
+        
+    top_mean0 = int(cropTop[:,:,0].mean())
+    top_mean1 = int(cropTop[:,:,1].mean())
+    top_mean2 = int(cropTop[:,:,2].mean())
+    left_mean0 = int(cropLeft[:,:,0].mean())
+    left_mean1 = int(cropLeft[:,:,1].mean())
+    left_mean2 = int(cropLeft[:,:,2].mean())
+    print('gym image param:',top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2)
+    gym_image_id = database.get_gym_image_id(session,top_mean0,top_mean1,top_mean2,left_mean0,left_mean1,left_mean2)
+    return gym_image_id
+
+def detectMon(img):
+    global mon_db
+    ret,bin_img = cv2.threshold(cv2.cvtColor(img,cv2.COLOR_BGR2GRAY),240,255,cv2.THRESH_BINARY_INV)
+    bin_color = cv2.cvtColor(bin_img,cv2.COLOR_GRAY2BGR)
+
+    height, width, channels = img.shape
+    if width == 320 and height == 525:
+        x1 = [288, 300]
+        y1 = [125, 195]    
+        crop1 = bin_img[y1[0]:y1[1], x1[0]:x1[1]]
+
+        x2 = [264, 280]
+        y2 = [234, 250]    
+        crop2 = bin_img[y2[0]:y2[1], x2[0]:x2[1]]
+
+        x3 = [244, 260]
+        y3 = [254, 270]    
+        crop3 = bin_img[y3[0]:y3[1], x3[0]:x3[1]]
+
+        x4 = [224, 240]
+        y4 = [270, 286]    
+        crop4 = bin_img[y4[0]:y4[1], x4[0]:x4[1]]
+
+        x5 = [310, 318]
+        y5 = [220, 350]    
+        crop5 = bin_img[y5[0]:y5[1], x5[0]:x5[1]]
+
+        x6 = [280, 308]
+        y6 = [270, 350]    
+        crop6 = bin_img[y6[0]:y6[1], x6[0]:x6[1]]
+
+        x7 = [244, 278]
+        y7 = [300, 350]    
+        crop7 = bin_img[y7[0]:y7[1], x7[0]:x7[1]]
+    else:
+        print('Unsuported image size')
+        session.close()
+        sys.exit(1)
+        return -1
+
+    mean1 = int(crop1.mean())
+    mean2 = int(crop2.mean())
+    mean3 = int(crop3.mean())
+    mean4 = int(crop4.mean())
+    mean5 = int(crop5.mean())
+    mean6 = int(crop6.mean())
+    mean7 = int(crop7.mean())
+    
+    min_error = 10000000
+    mon_id = 0
+    mon_image_id = 0
+    
+    # get error from all gyms
+    for mon in mon_db:
+        dif1 = pow(mean1 - mon.param_1,2)
+        dif2 = pow(mean2 - mon.param_2,2)
+        dif3 = pow(mean3 - mon.param_3,2)
+        dif4 = pow(mean4 - mon.param_4,2)
+        dif5 = pow(mean5 - mon.param_5,2)
+        dif6 = pow(mean6 - mon.param_6,2)
+        dif7 = pow(mean7 - mon.param_7,2)
+        error = math.sqrt(dif1+dif2+dif3+dif4+dif5+dif6+dif7)
+        # find minimum error
+        if error < min_error:
+            min_error = error
+            mon_id = mon.pokemon_id
+            mon_image_id = mon.id
+
+    if min_error > 5:
+        mon_id = -1
+        database.add_pokemon_image(session,0,mean1,mean2,mean3,mean4,mean5,mean6,mean7)
+        mon_image_id = database.get_pokemon_image_id(session,mean1,mean2,mean3,mean4,mean5,mean6,mean7)
+        # Reload pokemon_images
+        mon_db = [ mon for mon in database.get_pokemon_images(session)]
+
+    return mon_image_id, mon_id, min_error
+
+def get_pokemon_image_id(img):
+    ret,bin_img = cv2.threshold(cv2.cvtColor(img,cv2.COLOR_BGR2GRAY),240,255,cv2.THRESH_BINARY_INV)
+    bin_color = cv2.cvtColor(bin_img,cv2.COLOR_GRAY2BGR)
+    
+    height, width, channels = img.shape
+    if width == 320 and height == 525:
+        x1 = [288, 300]
+        y1 = [125, 195]    
+        crop1 = bin_img[y1[0]:y1[1], x1[0]:x1[1]]
+
+        x2 = [264, 280]
+        y2 = [234, 250]    
+        crop2 = bin_img[y2[0]:y2[1], x2[0]:x2[1]]
+
+        x3 = [244, 260]
+        y3 = [254, 270]    
+        crop3 = bin_img[y3[0]:y3[1], x3[0]:x3[1]]
+
+        x4 = [224, 240]
+        y4 = [270, 286]    
+        crop4 = bin_img[y4[0]:y4[1], x4[0]:x4[1]]
+
+        x5 = [310, 318]
+        y5 = [220, 350]    
+        crop5 = bin_img[y5[0]:y5[1], x5[0]:x5[1]]
+
+        x6 = [280, 308]
+        y6 = [270, 350]    
+        crop6 = bin_img[y6[0]:y6[1], x6[0]:x6[1]]
+
+        x7 = [244, 278]
+        y7 = [300, 350]    
+        crop7 = bin_img[y7[0]:y7[1], x7[0]:x7[1]]
+    else:
+        print('Unsuported image size')
+        session.close()
+        sys.exit(1)
+        return -1
+
+    mean1 = int(crop1.mean())
+    mean2 = int(crop2.mean())
+    mean3 = int(crop3.mean())
+    mean4 = int(crop4.mean())
+    mean5 = int(crop5.mean())
+    mean6 = int(crop6.mean())
+    mean7 = int(crop7.mean())
+
+    print('pokemon image param:',mean1,mean2,mean3,mean4,mean5,mean6,mean7)
+    pokemon_image_id = database.get_pokemon_image_id(session,mean1,mean2,mean3,mean4,mean5,mean6,mean7)
+    return pokemon_image_id
+
+def detectEgg(data):
+    if data[:7] == 'Ongoing' or data[:4] == 'Raid' or data == '':
+        return False
+    else:
+        return True
+
+def getHatchTime(data):
+    zero = datetime.datetime.now().replace(hour=0,minute=0,second=0,microsecond=0)
+    unix_zero = zero.timestamp()
+    #print(zero, int(unix_zero))
+    print('hatch_time =',data)
+    AM = data.find('AM')
+    if AM >= 5:
+        hour_min = data[:AM-1].split(':')
+        return int(unix_zero)+int(hour_min[0])*3600+int(hour_min[1])*60
+    PM = data.find('PM')
+    if PM >= 5:
+        hour_min = data[:PM-1].split(':')
+        if hour_min[0] == '12':
+            return int(unix_zero)+int(hour_min[0])*3600+int(hour_min[1])*60
+        else:
+            return int(unix_zero)+(int(hour_min[0])+12)*3600+int(hour_min[1])*60   
+
+def isRaidSighting(img):
+    ret = True
+    #print('image mean',img.mean())
+    if int(img.mean()) > 240:
+        #print('No raid sightings')
+        ret = False
+    return ret
+
+def processRaidImage(raidfilename):
+    filename = os.path.basename(raidfilename)
+    img_full = cv2.imread(str(raidfilename),3)
+
+    now = datetime.datetime.now()
+    unix_time = int(now.timestamp())
+    file_update_time = int(os.stat(str(raidfilename)).st_mtime)
+    #print(str(unix_time-file_update_time))
+
+    if isRaidSighting(img_full) == False:
+        os.remove(raidfilename)
+        return False
+
+    x1 = [0, 319]
+    y1 = [406, 450]
+    time_img = img_full[y1[0]:y1[1], x1[0]:x1[1]]    
+    #cv2.rectangle(img_egg,(x1[0],y1[0]),(x1[1],y1[1]),(0,255,0),1)
+
+    x2 = [0, 319]
+    y2 = [476, 524]
+    level_img = img_full[y2[0]:y2[1], x2[0]:x2[1]]    
+    #cv2.rectangle(img_egg,(x2[0],y2[0]),(x2[1],y2[1]),(0,255,0),1)    
+
+    time_text = detectTime(time_img)
+    level = detectLevel(level_img)
+    gym_image_id, gym, error_gym = detectGym(img_full)
+    egg = detectEgg(time_text)
+
+    update_raid = True    
+    # old file
+    if unix_time - file_update_time > 1800:
+        print("File is too old")
+        update_raid = False
+    if int(gym) > 0 and int(gym) != not_a_fort_id and int(gym) != unknown_fort_id:
+        if egg == True:
+            hatch_time = getHatchTime(time_text)
+            spawn_time = hatch_time - 3600
+            end_time = hatch_time + 2700
+            time_battle = database.get_raid_battle_time(session, gym)
+            print("Egg", level, time_text, gym, error_gym, hatch_time, time_battle)
+            if update_raid == True:
+                if int(time_battle) == int(hatch_time):
+                    print('This Egg is already assigned.')
+                else:
+                    database.update_raid_egg(session, gym, level, hatch_time)
+                    database.updata_fort_sighting(session, gym, unix_time)
+                    print('New Egg is added.')
+            else:
+                print('Skip update raid due to old file')
+        else:
+            mon_image_id, mon, error_mon = detectMon(img_full)
+            pokemon_id = database.get_raid_pokemon_id(session, gym)
+            print("Pokemon", level, time_text, gym, error_gym, mon, error_mon)
+            print('mon:',mon,'pokemon_id:',pokemon_id)
+            if int(mon) == int(pokemon_id) and int(mon) > 0:
+                print("This mon is already assigned.")
+            else:            
+                if int(mon) > 0:
+                    if update_raid == True:
+                        database.update_raid_mon(session, gym, mon)
+                        database.updata_fort_sighting(session, gym, unix_time)
+                        print('New raid boss is added.')
+                    else:
+                        print('Skip update raid due to old file')
+                elif int(mon) == 0:
+                    print('Pokemon image params are in database but the Pokemon is not known')
+                    unknown_mon_name = 'PokemonImage_'+str(mon_image_id)+'.png'
+                    fullpath_dest = str(copy_path) + str(unknown_mon_name)
+                    print(fullpath_dest)
+                    shutil.copy2(raidfilename,fullpath_dest)
+                else: # int(mon) < 0
+                    # Send mon image for training directory
+                    print('Mon is not in database')
+                    unknown_mon_name = 'PokemonImage_'+str(mon_image_id)+'.png'
+                    fullpath_dest = str(copy_path) + str(unknown_mon_name)
+                    print(fullpath_dest)
+                    shutil.copy2(raidfilename,fullpath_dest)
+                    
+    elif int(gym) == not_a_fort_id:
+        print('Raid image is not valid')
+    elif int(gym) == unknown_fort_id and egg == True:
+        # Send Image to Training Directory
+        print('Gym image params are in database but the Gym is not known')
+        unknown_gym_name = 'GymImage_'+str(gym_image_id)+'.png'
+        fullpath_dest = str(copy_path) + str(unknown_gym_name)
+        print(fullpath_dest)
+        shutil.copy2(raidfilename,fullpath_dest)
+    elif int(gym) == -1 and egg == True: # int(gym) < 0
+        # Send gym image for training directory
+        unknown_gym_name = 'GymImage_'+str(gym_image_id)+'.png'
+        fullpath_dest = str(copy_path) + str(unknown_gym_name)
+        print(fullpath_dest)
+        shutil.copy2(raidfilename,fullpath_dest)
+
+    os.remove(raidfilename)
+
+    #cv2.imshow('raid_image', img_full)
+    #cv2.waitKey(0)
+    return True
+
+def main():
+    while True:
+        for fullpath_filename in p.glob('*.png'):
+            processRaidImage(fullpath_filename)
+        time.sleep(3)
+    session.close()
+
+if __name__ == '__main__':
+    main()
+
+

--- a/Backend/raidscan.py
+++ b/Backend/raidscan.py
@@ -78,14 +78,29 @@ def detectGym(raid_img):
     global gym_db
     
     height, width, channels = raid_img.shape
-    if width == 320 and height == 525: 
-        cropTop = raid_img[40:70, 135:185]
-        cropLeft = raid_img[125:195, 45:70]
-    else:
-        print('Unsuported image size')
-        session.close()
-        sys.exit(1)
-        return -1
+    
+    org_top_y = 40
+    org_top_h = 30
+    org_top_x = 135
+    org_top_w = 50
+    org_left_y = 125
+    org_left_h = 70
+    org_left_x = 45
+    org_left_w = 25
+    
+    scale = width/320
+
+    top_y = int(org_top_y*scale)
+    top_h = int(org_top_h*scale)
+    top_x = int(org_top_x*scale)
+    top_w = int(org_top_w*scale)
+    left_y = int(org_left_y*scale)
+    left_h = int(org_left_h*scale)
+    left_x = int(org_left_x*scale)
+    left_w = int(org_left_w*scale)
+    
+    cropTop = raid_img[top_y:top_y+top_h, top_x:top_x+top_w]
+    cropLeft = raid_img[left_y:left_y+left_h, left_x:left_x+left_w]
             
     top_mean0 = int(cropTop[:,:,0].mean())
     top_mean1 = int(cropTop[:,:,1].mean())
@@ -132,14 +147,29 @@ def detectGym(raid_img):
 
 def get_gym_image_id(raid_img):
     height, width, channels = raid_img.shape
-    if width == 320 and height == 525: 
-        cropTop = raid_img[40:70, 135:185]
-        cropLeft = raid_img[125:195, 45:70]
-    else:
-        print('Unsuported image size')
-        session.close()
-        sys.exit(1)
-        return -1
+    
+    org_top_y = 40
+    org_top_h = 30
+    org_top_x = 135
+    org_top_w = 50
+    org_left_y = 125
+    org_left_h = 70
+    org_left_x = 45
+    org_left_w = 25
+    
+    scale = width/320
+
+    top_y = int(org_top_y*scale)
+    top_h = int(org_top_h*scale)
+    top_x = int(org_top_x*scale)
+    top_w = int(org_top_w*scale)
+    left_y = int(org_left_y*scale)
+    left_h = int(org_left_h*scale)
+    left_x = int(org_left_x*scale)
+    left_w = int(org_left_w*scale)
+    
+    cropTop = raid_img[top_y:top_y+top_h, top_x:top_x+top_w]
+    cropLeft = raid_img[left_y:left_y+left_h, left_x:left_x+left_w]
         
     top_mean0 = int(cropTop[:,:,0].mean())
     top_mean1 = int(cropTop[:,:,1].mean())
@@ -157,39 +187,46 @@ def detectMon(img):
     bin_color = cv2.cvtColor(bin_img,cv2.COLOR_GRAY2BGR)
 
     height, width, channels = img.shape
-    if width == 320 and height == 525:
-        x1 = [288, 300]
-        y1 = [125, 195]
-        crop1 = bin_img[y1[0]:y1[1], x1[0]:x1[1]]
+    
+    org_x1 = [288, 300]
+    org_y1 = [125, 195]
+    org_x2 = [264, 280]
+    org_y2 = [234, 250]    
+    org_x3 = [244, 260]
+    org_y3 = [254, 270]    
+    org_x4 = [224, 240]
+    org_y4 = [270, 286]    
+    org_x5 = [310, 318]
+    org_y5 = [220, 350]    
+    org_x6 = [280, 308]
+    org_y6 = [270, 350]    
+    org_x7 = [244, 278]
+    org_y7 = [300, 350]    
 
-        x2 = [264, 280]
-        y2 = [234, 250]    
-        crop2 = bin_img[y2[0]:y2[1], x2[0]:x2[1]]
+    scale = width/320
 
-        x3 = [244, 260]
-        y3 = [254, 270]    
-        crop3 = bin_img[y3[0]:y3[1], x3[0]:x3[1]]
-
-        x4 = [224, 240]
-        y4 = [270, 286]    
-        crop4 = bin_img[y4[0]:y4[1], x4[0]:x4[1]]
-
-        x5 = [310, 318]
-        y5 = [220, 350]    
-        crop5 = bin_img[y5[0]:y5[1], x5[0]:x5[1]]
-
-        x6 = [280, 308]
-        y6 = [270, 350]    
-        crop6 = bin_img[y6[0]:y6[1], x6[0]:x6[1]]
-
-        x7 = [244, 278]
-        y7 = [300, 350]    
-        crop7 = bin_img[y7[0]:y7[1], x7[0]:x7[1]]
-    else:
-        print('Unsuported image size')
-        session.close()
-        sys.exit(1)
-        return -1
+    x1 = [int(org_x1[0]*scale), int(org_x1[1]*scale)]
+    y1 = [int(org_y1[0]*scale), int(org_y1[1]*scale)]
+    x2 = [int(org_x2[0]*scale), int(org_x2[1]*scale)]
+    y2 = [int(org_y2[0]*scale), int(org_y2[1]*scale)]    
+    x3 = [int(org_x3[0]*scale), int(org_x3[1]*scale)]
+    y3 = [int(org_y3[0]*scale), int(org_y3[1]*scale)]    
+    x4 = [int(org_x4[0]*scale), int(org_x4[1]*scale)]
+    y4 = [int(org_y4[0]*scale), int(org_y4[1]*scale)]    
+    x5 = [int(org_x5[0]*scale), int(org_x5[1]*scale)]
+    y5 = [int(org_y5[0]*scale), int(org_y5[1]*scale)]    
+    x6 = [int(org_x6[0]*scale), int(org_x6[1]*scale)]
+    y6 = [int(org_y6[0]*scale), int(org_y6[1]*scale)]    
+    x7 = [int(org_x7[0]*scale), int(org_x7[1]*scale)]
+    y7 = [int(org_y7[0]*scale), int(org_y7[1]*scale)]    
+    
+    crop1 = bin_img[y1[0]:y1[1], x1[0]:x1[1]]
+    crop2 = bin_img[y2[0]:y2[1], x2[0]:x2[1]]
+    crop3 = bin_img[y3[0]:y3[1], x3[0]:x3[1]]
+    crop4 = bin_img[y4[0]:y4[1], x4[0]:x4[1]]
+    crop5 = bin_img[y5[0]:y5[1], x5[0]:x5[1]]
+    crop6 = bin_img[y6[0]:y6[1], x6[0]:x6[1]]
+    crop7 = bin_img[y7[0]:y7[1], x7[0]:x7[1]]
 
     mean1 = int(crop1.mean())
     mean2 = int(crop2.mean())
@@ -233,39 +270,46 @@ def get_pokemon_image_id(img):
     bin_color = cv2.cvtColor(bin_img,cv2.COLOR_GRAY2BGR)
     
     height, width, channels = img.shape
-    if width == 320 and height == 525:
-        x1 = [288, 300]
-        y1 = [125, 195]    
-        crop1 = bin_img[y1[0]:y1[1], x1[0]:x1[1]]
+    
+    org_x1 = [288, 300]
+    org_y1 = [125, 195]
+    org_x2 = [264, 280]
+    org_y2 = [234, 250]    
+    org_x3 = [244, 260]
+    org_y3 = [254, 270]    
+    org_x4 = [224, 240]
+    org_y4 = [270, 286]    
+    org_x5 = [310, 318]
+    org_y5 = [220, 350]    
+    org_x6 = [280, 308]
+    org_y6 = [270, 350]    
+    org_x7 = [244, 278]
+    org_y7 = [300, 350]    
 
-        x2 = [264, 280]
-        y2 = [234, 250]    
-        crop2 = bin_img[y2[0]:y2[1], x2[0]:x2[1]]
+    scale = width/320
 
-        x3 = [244, 260]
-        y3 = [254, 270]    
-        crop3 = bin_img[y3[0]:y3[1], x3[0]:x3[1]]
-
-        x4 = [224, 240]
-        y4 = [270, 286]    
-        crop4 = bin_img[y4[0]:y4[1], x4[0]:x4[1]]
-
-        x5 = [310, 318]
-        y5 = [220, 350]    
-        crop5 = bin_img[y5[0]:y5[1], x5[0]:x5[1]]
-
-        x6 = [280, 308]
-        y6 = [270, 350]    
-        crop6 = bin_img[y6[0]:y6[1], x6[0]:x6[1]]
-
-        x7 = [244, 278]
-        y7 = [300, 350]    
-        crop7 = bin_img[y7[0]:y7[1], x7[0]:x7[1]]
-    else:
-        print('Unsuported image size')
-        session.close()
-        sys.exit(1)
-        return -1
+    x1 = [int(org_x1[0]*scale), int(org_x1[1]*scale)]
+    y1 = [int(org_y1[0]*scale), int(org_y1[1]*scale)]
+    x2 = [int(org_x2[0]*scale), int(org_x2[1]*scale)]
+    y2 = [int(org_y2[0]*scale), int(org_y2[1]*scale)]    
+    x3 = [int(org_x3[0]*scale), int(org_x3[1]*scale)]
+    y3 = [int(org_y3[0]*scale), int(org_y3[1]*scale)]    
+    x4 = [int(org_x4[0]*scale), int(org_x4[1]*scale)]
+    y4 = [int(org_y4[0]*scale), int(org_y4[1]*scale)]    
+    x5 = [int(org_x5[0]*scale), int(org_x5[1]*scale)]
+    y5 = [int(org_y5[0]*scale), int(org_y5[1]*scale)]    
+    x6 = [int(org_x6[0]*scale), int(org_x6[1]*scale)]
+    y6 = [int(org_y6[0]*scale), int(org_y6[1]*scale)]    
+    x7 = [int(org_x7[0]*scale), int(org_x7[1]*scale)]
+    y7 = [int(org_y7[0]*scale), int(org_y7[1]*scale)]    
+    
+    crop1 = bin_img[y1[0]:y1[1], x1[0]:x1[1]]
+    crop2 = bin_img[y2[0]:y2[1], x2[0]:x2[1]]
+    crop3 = bin_img[y3[0]:y3[1], x3[0]:x3[1]]
+    crop4 = bin_img[y4[0]:y4[1], x4[0]:x4[1]]
+    crop5 = bin_img[y5[0]:y5[1], x5[0]:x5[1]]
+    crop6 = bin_img[y6[0]:y6[1], x6[0]:x6[1]]
+    crop7 = bin_img[y7[0]:y7[1], x7[0]:x7[1]]
 
     mean1 = int(crop1.mean())
     mean2 = int(crop2.mean())

--- a/Backend/raidscan.py
+++ b/Backend/raidscan.py
@@ -348,19 +348,24 @@ def getHatchTime(data):
     LOG.info('hatch_time ={}'.format(data))
     # US format
     AM = data.find('AM')
+    PM = data.find('PM')
     if AM >= 5:
         hour_min = data[:AM-1].split(':')
         return int(unix_zero)+int(hour_min[0])*3600+int(hour_min[1])*60
-    PM = data.find('PM')
-    if PM >= 5:
+    elif PM >= 5:
         hour_min = data[:PM-1].split(':')
         if hour_min[0] == '12':
             return int(unix_zero)+int(hour_min[0])*3600+int(hour_min[1])*60
         else:
             return int(unix_zero)+(int(hour_min[0])+12)*3600+int(hour_min[1])*60
     # Europe format
-    
-
+    else:
+        data.replace('~','')
+        data.replace('-','')
+        data.replace(' ','')
+        hour_min = data.split(':')
+        return int(unix_zero)+int(hour_min[0])*3600+int(hour_min[1])*60
+        
 def isRaidSighting(img):
     ret = True
     LOG.debug('image mean :{}'.format(img.mean()))

--- a/Backend/raidscan.py
+++ b/Backend/raidscan.py
@@ -15,6 +15,8 @@ import database
 
 process_img_path = os.getcwd() + '/process_img/'
 copy_path = os.getcwd() + '/unknown_img/'
+not_find_path = os.getcwd() + '/not_find_img/'
+
 
 # Create directories if not exists
 file_path = os.path.dirname(process_img_path)
@@ -26,6 +28,12 @@ file_path = os.path.dirname(copy_path)
 if not os.path.exists(file_path):
     print('unknown_img directory created')
     os.makedirs(file_path)
+
+file_path = os.path.dirname(not_find_path)
+if not os.path.exists(file_path):
+    print('unknown_img directory created')
+    os.makedirs(file_path)
+
 
 p = Path(process_img_path)
 
@@ -151,7 +159,7 @@ def detectMon(img):
     height, width, channels = img.shape
     if width == 320 and height == 525:
         x1 = [288, 300]
-        y1 = [125, 195]    
+        y1 = [125, 195]
         crop1 = bin_img[y1[0]:y1[1], x1[0]:x1[1]]
 
         x2 = [264, 280]
@@ -369,14 +377,14 @@ def processRaidImage(raidfilename):
                 elif int(mon) == 0:
                     print('Pokemon image params are in database but the Pokemon is not known')
                     unknown_mon_name = 'PokemonImage_'+str(mon_image_id)+'.png'
-                    fullpath_dest = str(copy_path) + str(unknown_mon_name)
+                    fullpath_dest = str(not_find_path) + str(unknown_mon_name)
                     print(fullpath_dest)
                     shutil.copy2(raidfilename,fullpath_dest)
                 else: # int(mon) < 0
                     # Send mon image for training directory
                     print('Mon is not in database')
                     unknown_mon_name = 'PokemonImage_'+str(mon_image_id)+'.png'
-                    fullpath_dest = str(copy_path) + str(unknown_mon_name)
+                    fullpath_dest = str(not_find_path) + str(unknown_mon_name)
                     print(fullpath_dest)
                     shutil.copy2(raidfilename,fullpath_dest)
                     

--- a/Backend/raidscan.py
+++ b/Backend/raidscan.py
@@ -57,7 +57,9 @@ not_a_fort_id = database.get_not_a_fort_id(session)
 def detectLevel(level_img):
     img_gray = cv2.cvtColor(level_img,cv2.COLOR_BGR2GRAY)
     ret,thresh1 = cv2.threshold(img_gray,240,255,cv2.THRESH_BINARY_INV)
-    level = int(cv2.sumElems(thresh1)[0]/level1_num + 0.2)
+    height, width, channel = level_img.shape()
+    scale = width/320
+    level = int(cv2.sumElems(thresh1)[0]/(level1_num*scale) + 0.2)
 #    cv2.imshow('level', thresh1)
 #    cv2.waitKey(0)
     return level

--- a/Backend/raidscan.py
+++ b/Backend/raidscan.py
@@ -387,13 +387,18 @@ def processRaidImage(raidfilename):
         os.remove(raidfilename)
         return False
 
-    x1 = [0, 319]
-    y1 = [406, 450]
+    height, width, channel = img_full.shape
+    
+    scale = width/320
+
+    x1 = [0, int(319*scale)]
+    y1 = [int(406*scale), int(450*scale)]    
     time_img = img_full[y1[0]:y1[1], x1[0]:x1[1]]    
     #cv2.rectangle(img_egg,(x1[0],y1[0]),(x1[1],y1[1]),(0,255,0),1)
 
-    x2 = [0, 319]
-    y2 = [476, 524]
+    
+    x2 = [0, int(319*scale)]
+    y2 = [int(476*scale), int(524*scale)]
     level_img = img_full[y2[0]:y2[1], x2[0]:x2[1]]    
     #cv2.rectangle(img_egg,(x2[0],y2[0]),(x2[1],y2[1]),(0,255,0),1)    
 

--- a/Backend/readme.md
+++ b/Backend/readme.md
@@ -1,0 +1,1 @@
+#RealDeviceRaidMap Backend

--- a/Backend/readme.md
+++ b/Backend/readme.md
@@ -1,1 +1,0 @@
-#RealDeviceRaidMap Backend

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,0 +1,9 @@
+opencv-python>=3.4.1.15
+opencv-contrib-python>=3.4.1.15
+pillow>=5.1.0
+pytesseract>=0.2.2
+SQLAlchemy>=1.2.8
+requests>=2.18.4
+mysqlclient>=1.3.12
+psycopg2>=2.7.4
+psycopg2-binary>=2.7.4


### PR DESCRIPTION
# RealDeviceRaidMap Backend
Backend for RealDeviceRaidMap. Identify Gym from Gym image and post extracted information to monocle hydro database. Most of gym images are identified automatically.

## Features
1. Read raid sightings images and identify
	* gym 
	* raid boss
	* start time
2. Parameters to identify gym and raid boss are stored in gym_images and pokemon_images table automatically.
3. Update raids and fort_sightings tables in monocle (Hydro) database
4. Download gym(fort) url images and find matching gym automatically. Up to 99% of gyms are detected successfully.
5. MySQL and Postgresql supported.
6. Currently only iPhone 7 and iPad resolution screenshot image supported in crop_backend.bash. If you would like to run other image size iOS device, edit crop_backend.bash

## How it works
### raidscan.py
Read all raid sightings png images cropped by `crop_backend.bash` in `process_img` directory and extract gym/raid boss/hatch time information and update `raids` and `fort_sightings` table for monocle Hydro database. If raidscan.py can't identify the gym then the gym image is stored in `unknown_img` as `FortImage_xxx.png`. Once gym is identified, check level and time. If time is Ongoing, then try to identify raid boss by checking `pokemon_images` table. If the raid boss is unknown, then store the raid boss image into `unknow_img` as PokemonImage_xxx.png.

### findfort.py
Read all gym images in `unknown_img` and identify the gym image by comparing fort URL images in `url_img`. If findfort.py finds matching gym(fort) in `url_img`, then update `gym_images` table to set identified `fort_id`. findfort.py checks images every 30 seconds. Fort URL images need to be downloaded by `downloadfortimg.py` before running `findfort.py`.

### downloadfortimg.py
Download all fort URL images in `Forts` table. Set `MAP_START` and `MAP_END` in `config.py` to limit fort URL images to download if you want.

### manualsubmit.py
`manualsubmit.py` update `fort_id` in `gym_images` and `pokemon_id` in `pokemon_images` by reading `Fort_xxx.png` and `Pokemon_yyy.png` in `not_find_img`. User need to set xxx for `fort_id` and yyy for `pokemon_id` manually. This part need to be integrated with `Frontend` in the future.

### Running order
1. Run `python3.6 downloadfortimg.py` once to download all gym(fort) URL image
2. Run `python3.6 raidscan.py` to scan raid images
3. Run `python3.6 findfort.py` to find gym if there is unknow gym
4. Run `bash crop_backend.bash` to crop captured screenshot and send to `process_img` folder for `raidscan.py`
5. Run `python3.6 manualsubmit.py` once you set `Fort_xxx.png` and `Pokemon_yyy.png` in `not_find_img` directory.

## Setting up
1. Install Python 3.6 (<https://www.python.org/downloads/release/python-365/>)
2. Install imagemagick 7+ `brew install imagemagick`
3. Install tesseract `brew install tesseract`
4. Create venv
    `python3.6 -m venv path/to/create/venv`
	example: `python3.6 -m venv ~/venv_rdrm`
5. Activate venv
    `source ~/venv_rdrm/bin/activate`
6. Install requirements
    `pip3.6 install -r requirements.txt -U`
    * If you don't have MySQL on your machine, comment out mysqlclient
    * If you don't have Postgresql on your machine, commment out psycopg2 and psycopg2-binary
7. Configure config.py to set your monocle database
8. Run `python3.6 raidscan.py` from the command line. When first run, raid_images and pokemon_images tables are added automatically.
9. Open another terminal and activate venv as in step 3
10. Run `python3.6 downloadfortimg.py`. If you don't want to download whole fort images in database, set `MAP_START` and `MAP_END` in `config.py`.
11. Wait finish download fort images, then run `python3.6 findfort.py`
12. Open crop_backend.bash and edit `RDRM_HOME_PATH` to your RealDeviceRaidMap directory.
13. Run `bach crop_backend.bash`. **Note. Currently Backend can't run with Frontend so Stop crop.bash before running crop_backend.bash**. Don't worry, Backend can identify gym images up to 99% of gyms automatically (without user input).
14. Wait until all gyms are identified. Check `success_img` and `need_check_img` directory to make sure all gym images are correctly identified.
15. `PokemonImage_xxx.png` files are stored in `unknown_img` directory. Rename the file to `Pokemon_PokemonId.png`(e.g. `Pokemon_380.png` for Latias) and run `python3.6 manualsubmit.py`. This will train pokemon raid boss. Usually only one time training should be enough.